### PR TITLE
feat: add google-workspace MCP server

### DIFF
--- a/services/helm/openagent/charts/hermes-agent/templates/_helpers.tpl
+++ b/services/helm/openagent/charts/hermes-agent/templates/_helpers.tpl
@@ -127,13 +127,42 @@ spec:
         - -c
         - |
           set -eu
-          dest="{{ .Values.persistence.mountPath }}/config.yaml"
+          mnt="{{ .Values.persistence.mountPath }}"
+
+          # Seed config.yaml (existing logic)
+          dest="$mnt/config.yaml"
           if [ "{{ .Values.bootstrap.overwrite }}" = "true" ] || [ ! -f "$dest" ]; then
             echo "Seeding $dest (overwrite={{ .Values.bootstrap.overwrite }})"
             cp /seed/config.yaml "$dest"
           else
             echo "Keeping existing $dest (overwrite=false)"
           fi
+
+          # Write Google OAuth Desktop credentials for google-workspace-mcp
+          if [ -n "${GOOGLE_OAUTH_CLIENT_ID:-}" ] && [ -n "${GOOGLE_OAUTH_CLIENT_SECRET:-}" ]; then
+            gw_dir="$mnt/.google-mcp"
+            mkdir -p "$gw_dir"
+            cat > "$gw_dir/credentials.json" <<- EOF
+          {
+            "installed": {
+              "client_id": "${GOOGLE_OAUTH_CLIENT_ID}",
+              "client_secret": "${GOOGLE_OAUTH_CLIENT_SECRET}",
+              "redirect_uris": ["http://localhost"],
+              "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+              "token_uri": "https://oauth2.googleapis.com/token"
+            }
+          }
+          EOF
+            echo "Wrote $gw_dir/credentials.json"
+          else
+            echo "SKIP: GOOGLE_OAUTH_CLIENT_ID or GOOGLE_OAUTH_CLIENT_SECRET not set"
+          fi
+      envFrom:
+        - secretRef:
+            name: {{ include "hermes-agent.fullname" . }}-env
+        {{- with .Values.extraEnvFrom }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumeMounts:
         - name: config
           mountPath: /seed

--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -251,6 +251,12 @@ hermes:
         tools:
           resources: false
           prompts: false
+
+      google-workspace:
+        command: "npx"
+        args: ["-y", "google-workspace-mcp"]
+        env:
+          GOOGLE_CREDENTIALS_PATH: "/opt/data/.google-mcp/credentials.json"
   env:
     OPENAI_API_KEY: unused
   extraEnv:


### PR DESCRIPTION
## Summary

Adds Google Workspace MCP server for Gmail, Drive, and Calendar access via Hermes.

## Changes

### `services/helm/openagent/values.yaml`
- Added `google-workspace` MCP server entry under `hermes.config.mcp_servers`
  - Uses `npx google-workspace-mcp` (95+ tools for Docs, Sheets, Drive, Gmail, Calendar, Slides, Forms)
  - Points `GOOGLE_CREDENTIALS_PATH` to persistent volume path

### `services/helm/openagent/charts/hermes-agent/templates/_helpers.tpl`
- Extended `seed-config` initContainer to construct Google OAuth Desktop credentials
  - Reads `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` from env (ESO-backed)
  - Writes `~/.google-mcp/credentials.json` on the persistent volume
  - Added `envFrom` with `secretRef` to the hermes-agent-env secret

## Prerequisites (already done)

- ✅ Google Cloud APIs enabled (Gmail, Calendar, Drive)
- ✅ OAuth Desktop client credentials exist in Doppler `devops/ci`
- ✅ Doppler refs set in `svc_openagent`: `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET`

## Post-merge

1. ArgoCD syncs → pod restarts
2. InitContainer writes config + credentials file
3. One-time OAuth authorization needed (visit URL from pod logs)
4. Tools available via `mcp_google_workspace_*`