### PR TITLE
feat: add LiteLLM Admin UI dashboard at litellm.maklab.net

### DIFF
--- a/services/helm/openagent/templates/shared/litellm-virtual-service.yaml
+++ b/services/helm/openagent/templates/shared/litellm-virtual-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: litellm
+  namespace: istio-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  hosts:
+    - {{ .Values.litellmVirtualService.host | quote }}
+  gateways:
+    - maklab-gateway
+  http:
+    - match:
+        - uri:
+            prefix: /
+      route:
+        - destination:
+            host: {{ .Values.litellmVirtualService.destination.host }}
+            port:
+              number: {{ .Values.litellmVirtualService.destination.port }}

--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -456,6 +456,13 @@ dashboard:
     host: "openagent-hermes-workspace.openagent.svc.cluster.local"
     port: 3000
 
+# ── LiteLLM Admin UI (VirtualService) ─────────────────────────────
+litellmVirtualService:
+  host: "litellm.maklab.net"
+  destination:
+    host: "openagent-litellm.openagent.svc.cluster.local"
+    port: 4000
+
 # ── VPA ────────────────────────────────────────────────────────────
 vpa:
   enabled: true


### PR DESCRIPTION
## What

Adds the LiteLLM Admin UI dashboard at `litellm.maklab.net` with CF Access OAuth protection.

## Changes

### `services/helm/openagent/templates/shared/litellm-virtual-service.yaml`
New VirtualService for `litellm.maklab.net` → `openagent-litellm.openagent.svc.cluster.local:4000`

### `services/helm/openagent/values.yaml`
Added `litellmVirtualService` config block

## How it works

1. `https://litellm.maklab.net/ui` → Google OAuth (CF Access)
2. Authenticate → Istio validates JWT → LiteLLM Admin UI
3. Manage keys, usage, models without editing config.yaml