### PR TITLE
Add BW_PASSWORD to Bitwarden MCP env config

### DIFF
--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -286,6 +286,7 @@ hermes:
         env:
           BW_CLIENT_ID: "${MCP_BW_CLIENT_ID}"
           BW_CLIENT_SECRET: "${MCP_BW_CLIENT_SECRET}"
+          BW_PASSWORD: "${MCP_BW_PASSWORD}"
         tools:
           resources: false
           prompts: false


### PR DESCRIPTION
Adds `BW_PASSWORD` to the Bitwarden MCP server in `values.yaml`, sourced from `MCP_BW_PASSWORD` in Doppler `devops/svc_openagent`.

This enables headless auto-unlock so the vault is ready on pod startup without interactive prompts.

**Data flow:**
- Doppler `MCP_BW_PASSWORD` → ESO `openagent-secrets` (dataFrom regexp `.*`) → pod `extraEnvFrom`
- Hermes `values.yaml`: `BW_PASSWORD: "${MCP_BW_PASSWORD}"` in `hermes.config.mcp_servers.bitwarden.env`