### PR TITLE
fix: rename MCP_BW_* refs to BW_* in MCP config

### DIFF
--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -284,9 +284,9 @@ hermes:
         command: "npx"
         args: ["-y", "@bitwarden/mcp-server"]
         env:
-          BW_CLIENT_ID: "${MCP_BW_CLIENT_ID}"
-          BW_CLIENT_SECRET: "${MCP_BW_CLIENT_SECRET}"
-          BW_PASSWORD: "${MCP_BW_PASSWORD}"
+          BW_CLIENT_ID: "${BW_CLIENT_ID}"
+          BW_CLIENT_SECRET: "${BW_CLIENT_SECRET}"
+          BW_PASSWORD: "${BW_PASSWORD}"
         tools:
           resources: false
           prompts: false


### PR DESCRIPTION
Rename env var refs in Bitwarden MCP config from `${MCP_BW_CLIENT_ID}` to `${BW_CLIENT_ID}` to match the new Doppler key names. The `MCP_BW_*` keys were renamed to `BW_*` in Doppler so `bw` CLI can natively pick them up via `BW_CLIENT_ID`/`BW_CLIENT_SECRET`/`BW_PASSWORD` env vars.