### PR TITLE
fix: auto-login wrapper for Bitwarden MCP

### DIFF
--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -281,8 +281,13 @@ hermes:
           prompts: false
 
       bitwarden:
-        command: "npx"
-        args: ["-y", "@bitwarden/mcp-server"]
+        command: "sh"
+        args:
+          - "-c"
+          - |
+            BW_CLIENTID=$BW_CLIENTID BW_CLIENTSECRET=$BW_CLIENTSECRET bw login --apikey 2>/dev/null
+            export BW_SESSION=$(bw unlock --passwordenv BW_PASSWORD 2>/dev/null | grep 'export BW_SESSION=' | sed "s/.*export BW_SESSION=\"//;s/\".*//")
+            exec npx -y @bitwarden/mcp-server
         env:
           BW_CLIENTID: "${BW_CLIENTID}"
           BW_CLIENTSECRET: "${BW_CLIENTSECRET}"

--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -284,8 +284,8 @@ hermes:
         command: "npx"
         args: ["-y", "@bitwarden/mcp-server"]
         env:
-          BW_CLIENT_ID: "${BW_CLIENT_ID}"
-          BW_CLIENT_SECRET: "${BW_CLIENT_SECRET}"
+          BW_CLIENTID: "${BW_CLIENTID}"
+          BW_CLIENTSECRET: "${BW_CLIENTSECRET}"
           BW_PASSWORD: "${BW_PASSWORD}"
         tools:
           resources: false


### PR DESCRIPTION
Wraps @bitwarden/mcp-server startup with bw login --apikey + unlock so BW_SESSION is set before MCP server starts. bw CLI v2026.7.0 doesnt read BW_CLIENTID/BW_CLIENTSECRET env vars for login, so we pass them explicitly and capture BW_SESSION via unlock --passwordenv.