### PR TITLE
fix: correct BW_SESSION parsing in Bitwarden MCP wrapper

### DIFF
--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -286,7 +286,7 @@ hermes:
           - "-c"
           - |
             BW_CLIENTID=$BW_CLIENTID BW_CLIENTSECRET=$BW_CLIENTSECRET bw login --apikey 2>/dev/null
-            export BW_SESSION=$(bw unlock --passwordenv BW_PASSWORD 2>/dev/null | grep 'export BW_SESSION=' | sed "s/.*export BW_SESSION=\"//;s/\".*//")
+            export BW_SESSION=$(BW_PASSWORD=$BW_PASSWORD bw unlock --passwordenv BW_PASSWORD 2>/dev/null | grep "BW_SESSION=" | sed "s/.*BW_SESSION=\"//;s/\".*//")
             exec npx -y @bitwarden/mcp-server
         env:
           BW_CLIENTID: "${BW_CLIENTID}"


### PR DESCRIPTION
Fixes grep pattern to match `$ export BW_SESSION=` instead of `export BW_SESSION=`. Also passes BW_PASSWORD via env var prefix for unlock command.