### PR TITLE
fix: add Istio AuthorizationPolicy for kubernetes-mcp-server

### DIFF
--- a/services/helm/openagent/templates/mcp-kubectl/authorization-policy.yaml
+++ b/services/helm/openagent/templates/mcp-kubectl/authorization-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: kubernetes-mcp-server
+  namespace: openagent
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubernetes-mcp-server
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals: ["cluster.local/ns/openagent/sa/default"]


### PR DESCRIPTION
## What

Adds an Istio AuthorizationPolicy in the openagent namespace that restricts access to the kubernetes-mcp-server service - only the default service account (Hermes pod) is allowed to connect.

## Why

The kubectl MCP server had zero auth on its HTTP endpoint. Any pod in the cluster could call the MCP endpoint and execute kubectl commands with elevated privileges.

## How

- security.istio.io/v1 AuthorizationPolicy with ALLOW action
- Selector targets pods with app.kubernetes.io/name: kubernetes-mcp-server
- Only allows cluster.local/ns/openagent/sa/default (the Hermes pod SA)
- Ambient mesh ztunnel enforces at L4 - implicit DENY for everything else