### PR TITLE
feat: add opendesign override chart

### DIFF
--- a/apps/argocd-appset/values.yaml
+++ b/apps/argocd-appset/values.yaml
@@ -102,9 +102,9 @@ opendesign:
     - name: opendesign.config.bindHost
       value: "127.0.0.1"
     - name: opendesign.config.allowedOrigins
-      value: "https://od.maklab.net"
+      value: "https://design.maklab.net"
     - name: opendesign.config.publicBaseUrl
-      value: "https://od.maklab.net"
+      value: "https://design.maklab.net"
     - name: opendesign.replicaCount
       value: "1"
     - name: opendesign.persistence.enabled

--- a/apps/argocd-appset/values.yaml
+++ b/apps/argocd-appset/values.yaml
@@ -86,3 +86,32 @@ apps:
         value: "{{ .Values.notesUi.environment.staging.dopplerConfig }}"
       - name: notesUi.environments.production.dopplerConfig
         value: "{{ .Values.notesUi.environment.production.dopplerConfig }}"
+
+opendesign:
+  enable: true
+  enable_private: true
+  helmPath: apps/helm/opendesign
+  project: default
+  environment:
+    production:
+      cluster: https://kubernetes.default.svc
+      namespace: opendesign
+  parameters:
+    - name: opendesign.config.disableApiAuth
+      value: "1"
+    - name: opendesign.config.bindHost
+      value: "127.0.0.1"
+    - name: opendesign.config.allowedOrigins
+      value: "https://od.maklab.net"
+    - name: opendesign.config.publicBaseUrl
+      value: "https://od.maklab.net"
+    - name: opendesign.replicaCount
+      value: "1"
+    - name: opendesign.persistence.enabled
+      value: "true"
+    - name: opendesign.persistence.storageClass
+      value: "local-path"
+    - name: opendesign.persistence.size
+      value: "10Gi"
+    - name: opendesign.ingress.enabled
+      value: "false"

--- a/apps/helm/opendesign/Chart.yaml
+++ b/apps/helm/opendesign/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: opendesign
+description: Open Design — values override layer for upstream chart
+version: 0.1.0
+appVersion: "0.7.0"

--- a/apps/helm/opendesign/README.md
+++ b/apps/helm/opendesign/README.md
@@ -1,0 +1,7 @@
+# OpenDesign
+
+Chart source: [nexu-io/open-design/charts/open-design](https://github.com/nexu-io/open-design/tree/main/charts/open-design)
+
+This directory is the values override layer. The ArgoCD Application points
+at the upstream repo directly. See `apps/argocd-appset/values.yaml` for
+the appset entry.

--- a/apps/helm/opendesign/values.yaml
+++ b/apps/helm/opendesign/values.yaml
@@ -9,8 +9,8 @@
 config:
   disableApiAuth: 1
   bindHost: "127.0.0.1"
-  allowedOrigins: "https://od.maklab.net"
-  publicBaseUrl: "https://od.maklab.net"
+  allowedOrigins: "https://design.maklab.net"
+  publicBaseUrl: "https://design.maklab.net"
   apiToken: "dummy"
 
 replicaCount: 1

--- a/apps/helm/opendesign/values.yaml
+++ b/apps/helm/opendesign/values.yaml
@@ -1,0 +1,32 @@
+# OpenDesign — values overrides
+# authProxy.enabled=false requires upstream PR #6093
+
+# authProxy:
+#   enabled: false
+# config:
+#   bindHost: "0.0.0.0"
+
+config:
+  disableApiAuth: 1
+  bindHost: "127.0.0.1"
+  allowedOrigins: "https://od.maklab.net"
+  publicBaseUrl: "https://od.maklab.net"
+  apiToken: "dummy"
+
+replicaCount: 1
+
+persistence:
+  enabled: true
+  storageClass: "local-path"
+  size: 10Gi
+
+ingress:
+  enabled: false
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 200m
+    memory: 256Mi


### PR DESCRIPTION
## Structure

```
apps/helm/opendesign/
  Chart.yaml    — metadata only
  values.yaml   — overrides (authProxy bits commented out)
  README.md

apps/argocd-appset/values.yaml
  opendesign entry with enable_private: true (private gateway)
```

## How it works

ArgoCD source points upstream at `nexu-io/open-design/charts/open-design`.
Gitops repo holds only the values override layer — no vendored charts.

Domain: `design.maklab.net` — already behind CF Access wildcard.

## Values

- `disableApiAuth: 1` — CF Access auth at edge (sidecar kept for now)
- `replicaCount: 1` — SQLite constraint
- PVC: 10Gi via local-path
- Ingress disabled — CF Access + Tunnel

## Pending

Once upstream [#6093](https://github.com/nexu-io/open-design/pull/6093) merges, uncomment:
```yaml
authProxy:
  enabled: false
config:
  bindHost: "0.0.0.0"
```