### PR TITLE
feat: route subagent delegation through LiteLLM (claude/sonnet-4)

### DIFF
--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -237,6 +237,13 @@ hermes-agent:
         - ALWAYS verbalize your classification: "Classified as [tier]."
         - Show your work. Tell user what you're doing.
         - When delegating: "Delegating to [persona] for [task]."
+    delegation:
+      model: claude/sonnet-4
+      provider: litellm
+      base_url: http://openagent-litellm.openagent.svc.cluster.local:4000/v1
+      api_key: ${LITELLM_MASTER_KEY}
+      max_iterations: 30
+      reasoning_effort: medium
     plugins:
       enabled:
         - discord-platform


### PR DESCRIPTION
Adds delegation config to route subagents through LiteLLM, giving them vision capabilities via claude/sonnet-4 (instead of the text-only deepseek-v4-flash).

**Changes:**
- `services/helm/openagent/values.yaml` — added `delegation` section to `hermes-agent.config`

**Traffic flow:**
```
delegate_task → LiteLLM (claude/sonnet-4) → claude-proxy → Anthropic
                ↳ fallback: deepseek-v4-pro
```

**What this enables:**
When img/audio requests hit the orchestrator (deepseek-v4-flash, text-only), `delegation` + `.hermes.md` route them to vision-capable subagents.

Closes the delegation setup.