### PR TITLE
Seed agentId as codex for LiteLLM

### DIFF
--- a/apps/helm/opendesign/templates/deployment.yaml
+++ b/apps/helm/opendesign/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
             - |
               if [ ! -f /app/.od/app-config.json ]; then
                 printf '{\n' > /app/.od/app-config.json
+                printf '  "onboardingCompleted": true,\n' >> /app/.od/app-config.json
+                printf '  "agentId": "codex",\n' >> /app/.od/app-config.json
                 printf '  "agentCliEnv": {\n' >> /app/.od/app-config.json
                 printf '    "codex": {\n' >> /app/.od/app-config.json
                 printf '      "OPENAI_BASE_URL": "%s",\n' "{{ .Values.provider.endpoint }}" >> /app/.od/app-config.json


### PR DESCRIPTION
Default agent was `amr` (Vela) which requires VELA_BIN.
We're wired for Codex → LiteLLM (OpenAI-compatible).

Sets `agentId: "codex"` and `onboardingCompleted: true`
in the seed-config init container so the UI skips the
agent picker and goes straight to the design surface.