### PR TITLE
Add Doppler ExternalSecret for opendesign

### DIFF
--- a/apps/helm/opendesign/templates/externalsecret.yaml
+++ b/apps/helm/opendesign/templates/externalsecret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: opendesign-secrets
+  namespace: opendesign
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-svc-openagent
+  target:
+    name: opendesign-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: LITELLM_MASTER_KEY
+      remoteRef:
+        key: LITELLM_MASTER_KEY


### PR DESCRIPTION
Adds an ExternalSecret in opendesign namespace that pulls
LITELLM_MASTER_KEY from Doppler using the same
ClusterSecretStore (doppler-svc-openagent) as openagent.

Replaces the hardcoded static secret with a proper
Doppler-backed secret managed by ExternalSecrets Operator.