### PR TITLE
feat: configure auxiliary vision provider for image analysis (claude/sonnet-4)

### DIFF
--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -244,6 +244,11 @@ hermes-agent:
       api_key: ${LITELLM_MASTER_KEY}
       max_iterations: 30
       reasoning_effort: medium
+
+    auxiliary:
+      vision:
+        provider: litellm
+        model: claude/sonnet-4
     plugins:
       enabled:
         - discord-platform


### PR DESCRIPTION
Adds `auxiliary.vision` config so the `vision_analyze` tool has a backend. Without this, image analysis silently fails.

**Changes:**
- `services/helm/openagent/values.yaml` — added `auxiliary.vision` block under `hermes-agent.config`

**Traffic flow:**
```
vision_analyze → LiteLLM (claude/sonnet-4) → claude-proxy → Anthropic
```

Required alongside the `delegation` config from PR #37 for full image processing pipeline.