### PR TITLE
feat(openagent): add gistpad MCP server

### DIFF
--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -252,6 +252,15 @@ hermes-agent:
           resources: false
           prompts: false
 
+      gistpad:
+        command: "npx"
+        args: ["-y", "gistpad-mcp"]
+        env:
+          GITHUB_TOKEN: "${MCP_GITHUB_TOKEN}"
+        tools:
+          resources: false
+          prompts: false
+
       argocd:
         command: "npx"
         args: ["-y", "argocd-mcp@latest", "stdio"]


### PR DESCRIPTION
## Summary
Adds [`gistpad-mcp`](https://github.com/lostintangent/gistpad-mcp) to Hermes MCP server config.

Enables reading/writing GitHub Gists directly from Hermes (list, get, create, update, etc.).

## Changes
- `services/helm/openagent/values.yaml`: added `gistpad` MCP entry reusing `MCP_GITHUB_TOKEN`

## No new secrets needed
Reuses existing `MCP_GITHUB_TOKEN` (scoped to `gist` among other scopes).