### PR TITLE
feat: add ExcaliDash (excalidash.maklab.net) via alekc/excalidash chart

### DIFF
--- a/apps/argocd-appset/values.yaml
+++ b/apps/argocd-appset/values.yaml
@@ -117,3 +117,15 @@ apps:
         value: "10Gi"
       - name: opendesign.ingress.enabled
         value: "false"
+
+  excalidash:
+    enable: false
+    enable_private: true
+    gateways:
+      enable_public: false
+    helmPath: apps/helm/excalidash
+    project: default
+    environment:
+      production:
+        cluster: https://kubernetes.default.svc
+        namespace: excalidash

--- a/apps/helm/excalidash/Chart.yaml
+++ b/apps/helm/excalidash/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: excalidash
+description: Values override layer for alekc/excalidash (self-hosted Excalidraw dashboard)
+type: application
+version: 1.0.0
+appVersion: "0.5.0"
+dependencies:
+  - name: excalidash
+    version: 1.0.0
+    repository: https://charts.alekc.dev

--- a/apps/helm/excalidash/README.md
+++ b/apps/helm/excalidash/README.md
@@ -1,0 +1,10 @@
+# ExcaliDash
+
+Values override layer for the upstream [alekc/excalidash](https://artifacthub.io/packages/helm/alekc/excalidash)
+chart (v1.0.0, repo `https://charts.alekc.dev`).
+
+- Domain: `excalidash.maklab.net` (private — CF Access Google OAuth at the edge, app-level `AUTH_MODE=local` login)
+- Secrets: Doppler config `svc_excalidash` → `doppler-svc-excalidash` ClusterSecretStore → k8s Secret `excalidash-secrets` (`JWT_SECRET`, `CSRF_SECRET`)
+- Storage: 5Gi `local-path` PVC at `/app/prisma` (SQLite, single backend replica)
+- Routing: VirtualService `excalidash` in the istio chart (`enablePrivate: true` → `require-cf-access-excalidash` DENY policy)
+- Backend env: `FRONTEND_URL`, `TRUST_PROXY=1`, `ENFORCE_HTTPS_REDIRECT=false` (edge TLS), `UPDATE_CHECK_OUTBOUND=false`

--- a/apps/helm/excalidash/templates/externalsecret.yaml
+++ b/apps/helm/excalidash/templates/externalsecret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: excalidash-secrets
+  namespace: excalidash
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-svc-excalidash
+  target:
+    name: excalidash-secrets
+    creationPolicy: Owner
+  data:
+    - secretKey: JWT_SECRET
+      remoteRef:
+        key: JWT_SECRET
+    - secretKey: CSRF_SECRET
+      remoteRef:
+        key: CSRF_SECRET

--- a/apps/helm/excalidash/values.yaml
+++ b/apps/helm/excalidash/values.yaml
@@ -1,0 +1,44 @@
+# Local values — consumed by templates/externalsecret.yaml
+dopplerConfig: "svc_excalidash"
+
+# ── Upstream chart overrides (alekc/excalidash v1.0.0) ─────────────────
+# Docs: https://artifacthub.io/packages/helm/alekc/excalidash
+excalidash:
+  ingress:
+    main:
+      enabled: false        # Routing via Istio VirtualService (istio chart)
+
+  persistence:
+    db:
+      enabled: true
+      accessMode: ReadWriteOnce
+      size: 5Gi
+      storageClass: local-path
+      targetSelector:
+        backend:
+          main:
+            mountPath: /app/prisma
+
+  # No static secrets — Doppler ExternalSecret (excalidash-secrets) provides JWT/CSRF
+  secret:
+    secrets:
+      enabled: false
+      data:
+        JWT_SECRET: ""
+        CSRF_SECRET: ""
+
+  workload:
+    backend:
+      podSpec:
+        containers:
+          main:
+            env:
+              FRONTEND_URL: https://excalidash.maklab.net
+              AUTH_MODE: local
+              TRUST_PROXY: "true"
+              UPDATE_CHECK_OUTBOUND: "false"
+              # Edge (CF Tunnel → Istio) terminates TLS; disable built-in redirect
+              ENFORCE_HTTPS_REDIRECT: "false"
+            envFrom:
+              - secretRef:
+                  name: excalidash-secrets

--- a/services/helm/external-secrets/values.yaml
+++ b/services/helm/external-secrets/values.yaml
@@ -26,6 +26,9 @@ clusterSecretStores:
   svc_openagent:
     project: devops
     config: svc_openagent
+  svc_excalidash:
+    project: devops
+    config: svc_excalidash
   zurabase-dev:
     project: zurabase
     config: dev

--- a/services/helm/istio/values.yaml
+++ b/services/helm/istio/values.yaml
@@ -97,6 +97,14 @@ virtualServices:
     destination:
       host: argo-cd-argocd-server.argocd.svc.cluster.local
       port: 80
+
+  excalidash:
+    enabled: true
+    host: excalidash.maklab.net
+    enablePrivate: true
+    destination:
+      host: excalidash.excalidash.svc.cluster.local
+      port: 80
   opencost:
     enabled: false
     host: opencost.maklab.net


### PR DESCRIPTION
## ExcaliDash deployment — excalidash.maklab.net

Adds the self-hosted Excalidraw dashboard via a values-override layer over the upstream [alekc/excalidash](https://artifacthub.io/packages/helm/alekc/excalidash) chart v1.0.0 (repo `https://charts.alekc.dev`).

### What

- **`apps/helm/excalidash/`** — dependency-based override chart (pattern: cert-manager / kube-prometheus-stack):
  - `Chart.yaml` — dependency on `alekc/excalidash` 1.0.0
  - `values.yaml` — `ingress.main.enabled=false` (Istio routes), `persistence.db` 5Gi `local-path`, chart secret disabled, backend env (`FRONTEND_URL`, `AUTH_MODE=local`, `TRUST_PROXY=1`, `ENFORCE_HTTPS_REDIRECT=false`, `UPDATE_CHECK_OUTBOUND=false`), `envFrom` → `excalidash-secrets`
  - `templates/externalsecret.yaml` — Doppler `doppler-svc-excalidash` → `JWT_SECRET` + `CSRF_SECRET` (sync-wave −1, no static secrets)
- **`services/helm/external-secrets/values.yaml`** — new `svc_excalidash` ClusterSecretStore (project `devops`, config `svc_excalidash`)
- **`services/helm/istio/values.yaml`** — `virtualServices.excalidash` → `excalidash.maklab.net` routed to `excalidash.excalidash.svc.cluster.local:80`, `enablePrivate: true` (renders `require-cf-access-excalidash` DENY policy; CF Access wildcard `*.maklab.net` covers the subdomain — no Terraform change)
- **`apps/argocd-appset/values.yaml`** — dormant `excalidash` entry (standalone Application, opendesign pattern)

### Prereq (Doppler)
`svc_excalidash` config in the `devops` project with `JWT_SECRET` + `CSRF_SECRET` — the ExternalSecret resolves once the store is valid.

### Post-merge
Create standalone Application `excalidash` (source `apps/helm/excalidash`, ns `excalidash`, CreateNamespace, automated prune/selfHeal), dry-run sync to verify rendered manifests (envFrom secret name), then sync.
