### PR TITLE
feat(excalidash): rename subdomain to draw.maklab.net + document ESO webhook cert fix

### DIFF
--- a/apps/helm/excalidash/README.md
+++ b/apps/helm/excalidash/README.md
@@ -3,7 +3,7 @@
 Values override layer for the upstream [alekc/excalidash](https://artifacthub.io/packages/helm/alekc/excalidash)
 chart (v1.0.0, repo `https://charts.alekc.dev`).
 
-- Domain: `excalidash.maklab.net` (private — CF Access Google OAuth at the edge, app-level `AUTH_MODE=local` login)
+- Domain: `draw.maklab.net` (private — CF Access Google OAuth at the edge, app-level `AUTH_MODE=local` login)
 - Secrets: Doppler config `svc_excalidash` → `doppler-svc-excalidash` ClusterSecretStore → k8s Secret `excalidash-secrets` (`JWT_SECRET`, `CSRF_SECRET`)
 - Storage: 5Gi `local-path` PVC at `/app/prisma` (SQLite, single backend replica)
 - Routing: VirtualService `excalidash` in the istio chart (`enablePrivate: true` → `require-cf-access-excalidash` DENY policy)

--- a/apps/helm/excalidash/values.yaml
+++ b/apps/helm/excalidash/values.yaml
@@ -34,7 +34,7 @@ excalidash:
         containers:
           main:
             env:
-              FRONTEND_URL: https://excalidash.maklab.net
+              FRONTEND_URL: https://draw.maklab.net
               AUTH_MODE: local
               TRUST_PROXY: "true"
               UPDATE_CHECK_OUTBOUND: "false"

--- a/services/helm/external-secrets/README.md
+++ b/services/helm/external-secrets/README.md
@@ -49,6 +49,7 @@ The store references `doppler-machine-token` in the `external-secrets` namespace
 | `doppler-svc-postgres-operator` | devops | svc_postgres_operator | postgres-operator |
 | `doppler-svc-onedev` | devops | svc_onedev | onedev |
 | `doppler-svc-mongodb` | devops | svc_mongodb | mongodb-operator, app PerconaServerMongoDB CRs |
+| `doppler-svc-excalidash` | devops | svc_excalidash | excalidash |
 | `doppler-svc-openclaw` | devops | svc_openclaw | openclaw |
 | `doppler-zurabase-dev` | zurabase | dev | future zurabase service |
 | `doppler-zurabase-stg` | zurabase | stg | future zurabase service |
@@ -93,3 +94,34 @@ Any chart that needs secrets must be in wave ≥ 2 (after ClusterSecretStores ex
 | external-secrets.replicaCount | int | `2` |  |
 | external-secrets.serviceAccount.create | bool | `true` |  |
 | external-secrets.webhook.certManager.enabled | bool | `false` |  |
+
+## Webhook cert lifecycle (`Replace=true` footgun)
+
+The external-secrets Application syncs with the `Replace=true` sync option
+(needed for CRD upgrades). `Replace` bypasses `ignoreDifferences`, so **any
+re-sync of this chart replaces** the helm-rendered `external-secrets-webhook`
+Secret and both ValidatingWebhookConfigurations with the chart's empty
+template — wiping the ESO-generated webhook CA/certs and the injected
+`caBundle`. The webhook then crash-loops (`stat /tmp/certs/tls.crt: no such
+file`) and **every ExternalSecret write fails cluster-wide** (`failed calling
+webhook ... no endpoints available` / `x509: certificate signed by unknown
+authority`).
+
+This is what happened on 2026-08-07: adding `svc_excalidash` to
+`clusterSecretStores` triggered an auto-sync that wiped the certs.
+
+### Protection (applied live)
+
+These resources carry `helm.sh/resource-policy: keep` so ArgoCD skips them on
+sync/prune and ESO manages them freely. If they are ever recreated, re-apply:
+
+- Secret `external-secrets/external-secrets-webhook`
+- ValidatingWebhookConfiguration `externalsecret-validate`
+- ValidatingWebhookConfiguration `secretstore-validate`
+
+### Recovery
+
+1. Restart the cert-controller — `kubectl delete pod -n external-secrets -l app.kubernetes.io/name=external-secrets-cert-controller`. It regenerates the CA + webhook certs and injects the `caBundle` into both webhook configs.
+2. If the webhook Secret was deleted, recreate it empty first (chart shape: labels + `type: Opaque`, no data). ESO writes certs into an existing secret; it does not create it.
+3. Re-apply `helm.sh/resource-policy: keep` on the Secret and both ValidatingWebhookConfigurations.
+4. Verify: webhook pod Ready, `clientConfig.caBundle` present on both ValidatingWebhookConfigurations, and `kubectl get externalsecret` no longer reports webhook errors.

--- a/services/helm/istio/values.yaml
+++ b/services/helm/istio/values.yaml
@@ -100,7 +100,7 @@ virtualServices:
 
   excalidash:
     enabled: true
-    host: excalidash.maklab.net
+    host: draw.maklab.net
     enablePrivate: true
     destination:
       host: excalidash.excalidash.svc.cluster.local


### PR DESCRIPTION
## ExcaliDash: subdomain → `draw.maklab.net` + ESO webhook cert fix docs

### Rename
- `apps/helm/excalidash/values.yaml` — backend `FRONTEND_URL` → `https://draw.maklab.net`
- `apps/helm/excalidash/README.md` — domain reference
- `services/helm/istio/values.yaml` — `virtualServices.excalidash.host` → `draw.maklab.net` (VS resource name stays `excalidash`)

CF Access wildcard `*.maklab.net` covers the new subdomain — no Terraform change.

### Docs (fix found during deploy — attached per convention)
- `services/helm/external-secrets/README.md` — new **Webhook cert lifecycle (`Replace=true` footgun)** section documenting:
  - how `Replace=true` + empty chart templates wipe the ESO webhook certs on any re-sync (broke cluster-wide ES writes on 2026-08-07)
  - the `helm.sh/resource-policy: keep` protection applied live on the webhook Secret + both ValidatingWebhookConfigurations
  - the recovery procedure (restart cert-controller, recreate empty secret if deleted, re-apply keep)
- Added `doppler-svc-excalidash` row to the ClusterSecretStore table

### Post-merge
ArgoCD auto-syncs: VS host updates, backend env updates on next excalidash sync (pending Doppler config `svc_excalidash`).