### PR TITLE
feat(openagent): us-tax-filing-automation skill (GitOps) + IRS W&I transcript parser

### DIFF
--- a/services/helm/openagent/files/skills/us-tax-filing-automation/parse_wi_transcript.py
+++ b/services/helm/openagent/files/skills/us-tax-filing-automation/parse_wi_transcript.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Parse an IRS Wage & Income transcript (PDF or raw text) into structured JSON.
+
+Usage:
+    uv run --with pypdf parse_wi_transcript.py transcript.pdf [-o transcripts.json]
+    parse_wi_transcript.py transcript.txt              # raw text fallback
+
+Output shape:
+{
+  "year_hint": "2025",
+  "w2s":  [{"employer": ..., "ein": ..., "wages": ..., "fed_withheld": ...,
+            "ss_wages": ..., "ss_withheld": ..., "medicare_wages": ...,
+            "medicare_withheld": ..., "state": ..., "state_withheld": ...}],
+  "1099s": [{"type": "INT", "payer": ..., "tin": ..., "amounts": {...}}]
+}
+
+Notes:
+- W&I transcripts have a consistent text layout; this is regex-driven on
+  extracted text. Section headers like "WAGE AND TAX STATEMENT" (W-2),
+  "INTEREST INCOME" (1099-INT), "DIVIDENDS AND DISTRIBUTIONS" (1099-DIV),
+  "NONEMPLOYEE COMPENSATION" (1099-NEC), "PAYMENTS IN LIEU OF DIVIDENDS",
+  "UNEMPLOYMENT COMPENSATION" (1099-G), "SOCIAL SECURITY BENEFIT" (1099-SSA)
+  split the document into records.
+- PDFs with a "This is a copy of your information" cover page are skipped.
+- Re-verify extracted numbers against the PDF before e-filing.
+"""
+import json
+import re
+import sys
+
+try:
+    from pypdf import PdfReader
+except ImportError:
+    PdfReader = None
+
+DOC_HEADERS = [
+    ("W-2", "WAGE AND TAX STATEMENT"),
+    ("SSA", "SOCIAL SECURITY BENEFIT STATEMENT"),
+    ("INT", "INTEREST INCOME"),
+    ("DIV", "DIVIDENDS AND DISTRIBUTIONS"),
+    ("NEC", "NONEMPLOYEE COMPENSATION"),
+    ("MISC", "MISCELLANEOUS INCOME"),
+    ("G", "UNEMPLOYMENT COMPENSATION"),
+    ("R", "PENSION OR ANNUITY"),
+    ("B", "PROCEEDS FROM BROKER"),
+    ("K", "PARTNER'S SHARE OF INCOME"),
+]
+
+MONEY_RE = re.compile(r"([-]?\$?[\d,]+\.\d{2})")
+EIN_RE = re.compile(r"\b(\d{2}-?\d{7})\b")
+
+
+def extract_text(path: str) -> str:
+    if path.lower().endswith((".txt", ".text")):
+        return open(path, encoding="utf-8", errors="replace").read()
+    if PdfReader is None:
+        sys.exit("pypdf not installed — run with: uv run --with pypdf " + sys.argv[0])
+    reader = PdfReader(path)
+    return "\n".join((page.extract_text() or "") for page in reader.pages)
+
+
+def split_documents(text: str):
+    """Return list of (doc_type, chunk_text)."""
+    lines = text.splitlines()
+    docs, cur_type, cur = [], None, []
+    for line in lines:
+        up = line.strip().upper()
+        matched = None
+        for t, h in DOC_HEADERS:
+            # header must be a standalone line (or header + trailing label, no $)
+            if re.match(r"^" + re.escape(h) + r"$", up) or (
+                up.startswith(h) and "$" not in line
+            ):
+                matched = (t, h)
+                break
+        if matched:
+            if cur_type:
+                docs.append((cur_type, "\n".join(cur)))
+            cur_type, cur = matched[0], [line]
+        elif cur_type:
+            cur.append(line)
+    if cur_type:
+        docs.append((cur_type, "\n".join(cur)))
+    return docs
+
+
+def _money_on_line(line: str, label: str):
+    m = re.search(label + r"[\s.]+([-]?\$?[\d,]+\.\d{2})", line, re.I)
+    return float(m.group(1).replace(",", "").replace("$", "")) if m else None
+
+
+def parse_w2(chunk: str) -> dict:
+    labels = {
+        "wages": "Wages, tips, other comp",
+        "fed_withheld": "Federal income tax withheld",
+        "ss_wages": "Social security wages",
+        "ss_withheld": "Social security tax withheld",
+        "medicare_wages": "Medicare wages and tips",
+        "medicare_withheld": "Medicare tax withheld",
+        "state_withheld": "State income tax",
+    }
+    fields = {}
+    for line in chunk.splitlines():
+        for key, label in labels.items():
+            if key not in fields:
+                v = _money_on_line(line, label)
+                if v is not None:
+                    fields[key] = v
+
+    ein = None
+    for pat in (r"Employer.?s? identification number[:\s]+([\d\-]+)",
+                r"\bEIN[:\s]*([\d\-]{9,10})\b"):
+        m = re.search(pat, chunk, re.I)
+        if m:
+            ein = m.group(1)
+            break
+    if not ein:
+        m = EIN_RE.search(chunk)
+        ein = m.group(1) if m else None
+
+    name = None
+    m = re.search(r"Employer.?s? name[:\s]+(.+)", chunk, re.I)
+    if m:
+        name = m.group(1).strip()
+
+    state = None
+    m = re.search(r"\bState[:\s]+([A-Z]{2})\b", chunk)
+    if m:
+        state = m.group(1)
+
+    return {
+        "employer": name,
+        "ein": ein,
+        "wages": fields.get("wages"),
+        "fed_withheld": fields.get("fed_withheld"),
+        "ss_wages": fields.get("ss_wages"),
+        "ss_withheld": fields.get("ss_withheld"),
+        "medicare_wages": fields.get("medicare_wages"),
+        "medicare_withheld": fields.get("medicare_withheld"),
+        "state": state,
+        "state_withheld": fields.get("state_withheld"),
+    }
+
+
+def parse_1099(doc_type: str, chunk: str) -> dict:
+    payer = None
+    m = re.search(r"Payer.?s? name[:\s]+(.+)", chunk, re.I)
+    if m:
+        payer = m.group(1).strip()
+    tin = None
+    m = re.search(r"Payer.?s? TIN[:\s]*([\d\-]+)", chunk, re.I)
+    if m:
+        tin = m.group(1)
+    amounts = {}
+    for line in chunk.splitlines()[:40]:
+        m = re.match(r"([A-Za-z][A-Za-z ,]+?)\s*[.:]+ ?\$?([\d,]+\.\d{2})\s*$", line.strip())
+        if m:
+            label = m.group(1).strip()
+            if label.lower() not in ("document id", "sequence", "form", "page"):
+                amounts[label] = float(m.group(2).replace(",", ""))
+    return {"type": doc_type, "payer": payer, "tin": tin, "amounts": amounts}
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit(__doc__)
+    text = extract_text(sys.argv[1])
+    out = {"w2s": [], "1099s": []}
+    for doc_type, chunk in split_documents(text):
+        if doc_type == "W-2":
+            rec = parse_w2(chunk)
+            if rec["wages"] is not None or rec["employer"]:
+                out["w2s"].append(rec)
+        else:
+            rec = parse_1099(doc_type, chunk)
+            if rec["payer"] or rec["amounts"]:
+                out["1099s"].append(rec)
+    year = re.search(r"\b(20\d{2})\b", text)
+    out["year_hint"] = year.group(1) if year else None
+    print(json.dumps(out, indent=2))
+    if len(sys.argv) > 2 and sys.argv[2] == "-o":
+        with open(sys.argv[3], "w", encoding="utf-8") as f:
+            json.dump(out, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/helm/openagent/files/skills/us-tax-filing-automation/payroll-registry.json
+++ b/services/helm/openagent/files/skills/us-tax-filing-automation/payroll-registry.json
@@ -1,0 +1,38 @@
+{
+  "_comment": "Payroll/records provider registry for IRS W&I transcript cross-matching. 'detect' hints match payer/employer names found in transcripts. Records NOT in the IRS W&I transcript (payer never filed) must be fetched from the portal directly.",
+  "payroll_providers": [
+    {"id": "adp", "name": "ADP", "portal": "https://my.adp.com", "record": "W-2",
+     "detect": ["automatic data processing", "adp, inc", "adp total source"], "notes": "Most common for mid/large employers; W-2 issuer name on transcript is the EMPLOYER, not ADP — match by employer name instead."},
+    {"id": "gusto", "name": "Gusto", "portal": "https://app.gusto.com", "record": "W-2",
+     "detect": ["gusto"], "notes": "Small business payroll; employee login downloads W-2 PDFs."},
+    {"id": "paychex", "name": "Paychex", "portal": "https://www.paychex.com", "record": "W-2",
+     "detect": ["paychex"], "notes": ""},
+    {"id": "intuit-qb", "name": "QuickBooks Payroll", "portal": "https://payroll.intuit.com", "record": "W-2",
+     "detect": ["intuit", "quickbooks"], "notes": "Intuit API exists (OAuth partner approval) — v3 transport."},
+    {"id": "rippling", "name": "Rippling", "portal": "https://app.rippling.com", "record": "W-2",
+     "detect": ["rippling"], "notes": ""},
+    {"id": "workday", "name": "Workday", "portal": "https://www.myworkday.com", "record": "W-2",
+     "detect": ["workday"], "notes": "Employer-specific tenant URL needed."},
+    {"id": "ukg", "name": "UKG / Kronos", "portal": "https://www.myukg.com", "record": "W-2",
+     "detect": ["ukg", "kronos", "ultipro"], "notes": ""},
+    {"id": "paylocity", "name": "Paylocity", "portal": "https://access.paylocity.com", "record": "W-2",
+     "detect": ["paylocity"], "notes": ""},
+    {"id": "trinet", "name": "TriNet", "portal": "https://trinet.com", "record": "W-2",
+     "detect": ["trinet"], "notes": ""},
+    {"id": "surepayroll", "name": "SurePayroll", "portal": "https://www.surepayroll.com", "record": "W-2",
+     "detect": ["surepayroll"], "notes": ""},
+    {"id": "square", "name": "Square Payroll", "portal": "https://squareup.com", "record": "W-2",
+     "detect": ["square"], "notes": ""},
+    {"id": "justworks", "name": "Justworks", "portal": "https://www.justworks.com", "record": "W-2",
+     "detect": ["justworks"], "notes": ""},
+    {"id": "bamboohr", "name": "BambooHR Payroll", "portal": "https://www.bamboohr.com", "record": "W-2",
+     "detect": ["bamboo"], "notes": ""}
+  ],
+  "brokerage_1099": [
+    {"id": "fidelity", "name": "Fidelity", "portal": "https://www.fidelity.com", "record": "1099-DIV/INT/B", "detect": ["fidelity"]},
+    {"id": "schwab", "name": "Charles Schwab", "portal": "https://www.schwab.com", "record": "1099-DIV/INT/B", "detect": ["schwab"]},
+    {"id": "vanguard", "name": "Vanguard", "portal": "https://investor.vanguard.com", "record": "1099-DIV/INT/B", "detect": ["vanguard"]},
+    {"id": "robinhood", "name": "Robinhood", "portal": "https://robinhood.com", "record": "1099-DIV/INT/B", "detect": ["robinhood"]},
+    {"id": "coinbase", "name": "Coinbase", "portal": "https://www.coinbase.com", "record": "1099-MISC/NEC/DA", "detect": ["coinbase"]}
+  ]
+}

--- a/services/helm/openagent/templates/skills/us-tax-filing-automation.yaml
+++ b/services/helm/openagent/templates/skills/us-tax-filing-automation.yaml
@@ -12,7 +12,7 @@ data:
     ---
     name: us-tax-filing-automation
     description: "Automate US federal + Minnesota income tax filing for free — IRS records ingestion (Get Transcript online → parser → payroll registry), obscura-driven FreeTaxUSA e-file (current + prior years), paper-filing workflow for old years."
-    version: 2.1.0
+    version: 2.2.0
     author: Hermes Agent
     license: MIT
     platforms: [linux, macos, windows]
@@ -48,8 +48,9 @@ data:
     1. **IRS Get Transcript online** (irs.gov/individuals/get-transcript) via obscura — ID.me login (MFA = human gate; "remember device" ≈ 1yr session).
     2. Download **Wage & Income transcript** PDF (every W-2/1099 filed against SSN — the authoritative aggregate).
     3. Parse: `scripts/parse_wi_transcript.py <pdf>` → `transcripts.json` (payer EIN, wages, fed/state withholding, 1099-INT/DIV/NEC/R).
-    4. Match payers against `references/payroll-registry.json` → missing/incomplete records → obscura drives the payroll portal (ADP/Gusto/…, brokered creds).
-    5. Flag gaps (payer never filed) → manual fetch.
+    4. **Fetch actual form copies** — for EVERY payer in transcripts.json, obtain the real W-2 / 1099 PDF: portal download via obscura (payroll/brokerage registry) or employer/payer copy. The transcript is the data source; the form PDFs are the archival record.
+    5. Match payers against `references/payroll-registry.json` → missing/incomplete records → obscura drives the payroll portal (ADP/Gusto/…, brokered creds).
+    6. Flag gaps (payer never filed) → manual fetch.
 
     ### 2. File current + prior years (e-file)
 
@@ -70,11 +71,16 @@ data:
 
     ### 4. Archive to Google Drive (taxes/<year>)
 
-    1. Stage everything in `/opt/data/tax/<year>/` (local, PVC-backed): `transcripts.json`, W&I transcript PDF, filed federal+state PDFs, e-file acceptance/status, paper mailing copies, IRS/MN correspondence.
+    1. Stage in `/opt/data/tax/<year>/` (local, PVC-backed) with this exact layout:
+       - `source_w2s/` — **actual W-2 PDFs** (one per employer; from payroll portal or employer copy)
+       - `source_1099s/` — **actual 1099 PDFs** (INT/DIV/NEC/MISC/R/B/SSA; one per payer)
+       - `wi_transcript.pdf` + `transcripts.json` (IRS data + parsed records)
+       - `filed/` — **completed filed forms**: federal 1040 + schedules, MN M1 + schedules (PDF)
+       - `confirmations/` — e-file acceptance/status, IRS/MN correspondence, certified-mail receipts
     2. Upload via google-workspace MCP (`user_google_email: joe3rdwash@gmail.com`):
-       - ensure folder exists: `create_drive_folder` (parent `taxes`, name `<year>`); create root `taxes` once
+       - ensure root `taxes` exists (once), then `create_drive_folder` `taxes/<year>` + subfolders (`source_w2s`, `source_1099s`, `filed`, `confirmations`)
        - `create_drive_file` per staged file (mime `application/pdf` / `application/json` / `text/plain`)
-    3. Convention: `taxes/2025`, `taxes/2024`, … under Drive root. Local copy retained; Drive is the durable archive.
+    3. Convention: `taxes/2025/source_w2s/*.pdf`, `taxes/2025/source_1099s/*.pdf`, `taxes/2025/filed/*.pdf`, `taxes/2025/confirmations/*`. Local copy retained; Drive is the durable archive.
 
     ## Pitfalls & reality checks
 

--- a/services/helm/openagent/templates/skills/us-tax-filing-automation.yaml
+++ b/services/helm/openagent/templates/skills/us-tax-filing-automation.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: openagent-skill-us-tax-filing-automation
-  namespace: {{ .Values.namespace }}
+  namespace: {{{{ .Values.namespace }}}}
   labels:
     app.kubernetes.io/part-of: openagent
   annotations:
@@ -12,7 +12,7 @@ data:
     ---
     name: us-tax-filing-automation
     description: "Automate US federal + Minnesota income tax filing for free — IRS records ingestion (Get Transcript online → parser → payroll registry), obscura-driven FreeTaxUSA e-file (current + prior years), paper-filing workflow for old years."
-    version: 2.0.0
+    version: 2.1.0
     author: Hermes Agent
     license: MIT
     platforms: [linux, macos, windows]
@@ -68,12 +68,21 @@ data:
     3. Federal: address depends on form + payment/no-payment + state → fetch current from irs.gov "where to file" (obscura). Payments: check + Form 1040-V via REGULAR mail (private couriers delay payment processing).
     4. Certified mail w/ return receipt = proof of filing date. Keep copies.
 
+    ### 4. Archive to Google Drive (taxes/<year>)
+
+    1. Stage everything in `/opt/data/tax/<year>/` (local, PVC-backed): `transcripts.json`, W&I transcript PDF, filed federal+state PDFs, e-file acceptance/status, paper mailing copies, IRS/MN correspondence.
+    2. Upload via google-workspace MCP (`user_google_email: joe3rdwash@gmail.com`):
+       - ensure folder exists: `create_drive_folder` (parent `taxes`, name `<year>`); create root `taxes` once
+       - `create_drive_file` per staged file (mime `application/pdf` / `application/json` / `text/plain`)
+    3. Convention: `taxes/2025`, `taxes/2024`, … under Drive root. Local copy retained; Drive is the durable archive.
+
     ## Pitfalls & reality checks
 
     - **Refund claims expire 3 years after due date.** TY2022 refunds forfeited (~4/15/2026). TY2023 expires 4/15/2027.
     - **Old years that owe**: FTF 5%/mo (cap 25%) + FTP 0.5%/mo + interest (fed + MN). Request **First-Time Penalty Abatement** (3 clean prior years) or reasonable cause.
     - **ToS**: automating FreeTaxUSA/Cash App violates their ToS — account-ban risk, low for personal use, real. Low volume only.
     - **Automation ceiling**: ID.me MFA, e-file attestation, the mailbox — human. Everything before is automatable.
+    - **google-workspace MCP OAuth**: Drive/Gmail tokens can expire or be wiped (pod restarts). Re-auth: `kubectl port-forward -n openagent <hermes-pod> 8000:8000`, then open the consent URL from the MCP error/`start_google_auth` in a browser — callback lands on localhost:8000 → port-forward → pod. Tokens live in `/opt/data/.google_workspace_mcp/credentials/`.
     - **MN amended returns**: e-filable from TY2025.
     - **State returns**: FreeTaxUSA MN = $15.99/$17.99; Cash App free but current-year only; OLT free-state claim — verify at signup.
     - Re-verify every season: the IRS free-filing program set changes drastically year to year.

--- a/services/helm/openagent/templates/skills/us-tax-filing-automation.yaml
+++ b/services/helm/openagent/templates/skills/us-tax-filing-automation.yaml
@@ -1,0 +1,85 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openagent-skill-us-tax-filing-automation
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/part-of: openagent
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+data:
+  us-tax-filing-automation.SKILL.md: |
+    ---
+    name: us-tax-filing-automation
+    description: "Automate US federal + Minnesota income tax filing for free — IRS records ingestion (Get Transcript online → parser → payroll registry), obscura-driven FreeTaxUSA e-file (current + prior years), paper-filing workflow for old years."
+    version: 2.0.0
+    author: Hermes Agent
+    license: MIT
+    platforms: [linux, macos, windows]
+    metadata:
+      hermes:
+        tags: [tax, irs, filing, freetaxusa, obscura, minnesota, automation]
+    ---
+
+    # US Tax Filing Automation (MN)
+
+    Goal: file current AND prior-year returns electronically for free, driven by Hermes. Facts below verified Aug 2026 — **re-verify program status each filing season** (Direct File's death shows how fast this landscape shifts).
+
+    ## 2026 Filing Season Facts (verified)
+
+    - **IRS Direct File: DISCONTINUED for Filing Season 2026** (IRS told 25 partner states Nov 2025, no relaunch date). Don't design around it.
+    - **IRS Free File**: 8 partner sites, **federal only**, AGI ≤ **$89,000** (TY2025). No prior years. **User's AGI > $89k → ineligible** (also ineligible for MN Free E-File, same cap).
+    - **FreeTaxUSA**: free federal at ANY income, current + prior years. MN state $15.99 (TY2025) / $17.99 (prior yrs). Prior-year e-file window: TY2025, TY2024 (~Nov 2027), TY2023 (~Nov 2026). TY2022+ = paper only.
+    - **Prior-year e-file requires an IRS IP PIN** (one-time ID.me verification). Paper returns do NOT need an IP PIN.
+    - **OLT.com**: prior-year federal + state e-file (advertised free; verify MN state price at signup). Backup to FreeTaxUSA.
+    - **Cash App Taxes**: free fed + state (~40 states + DC, MN historically included), no income cap, **current year only**, app-based, federal must file first.
+    - **TurboTax: never** — "Free Edition" is W-2-only upsell funnel; Intuit left IRS Free File 2021.
+
+    ## Stack (decided)
+
+    - **Obscura MCP** (`mcp__obscura__browser_*`) = the browser engine. Drives FreeTaxUSA / IRS Get Transcript online / payroll portals. Stealth on. **No freetaxusa-mcp fork** (Playwright/Chromium, stubbed tools — rejected; obscura direct wins).
+    - **irs-taxpayer-mcp** (`npx -y irs-taxpayer-mcp`): local calc cross-check before e-file. Optional.
+    - **Search**: DDG lite (`https://lite.duckduckgo.com/lite/?q=...`) via obscura — Bing/Google wall datacenter IPs; DDG lite doesn't.
+
+    ## Workflow
+
+    ### 1. Gather records (IRS-first)
+
+    1. **IRS Get Transcript online** (irs.gov/individuals/get-transcript) via obscura — ID.me login (MFA = human gate; "remember device" ≈ 1yr session).
+    2. Download **Wage & Income transcript** PDF (every W-2/1099 filed against SSN — the authoritative aggregate).
+    3. Parse: `scripts/parse_wi_transcript.py <pdf>` → `transcripts.json` (payer EIN, wages, fed/state withholding, 1099-INT/DIV/NEC/R).
+    4. Match payers against `references/payroll-registry.json` → missing/incomplete records → obscura drives the payroll portal (ADP/Gusto/…, brokered creds).
+    5. Flag gaps (payer never filed) → manual fetch.
+
+    ### 2. File current + prior years (e-file)
+
+    1. FreeTaxUSA via obscura — login, select tax year (prior years supported).
+    2. Fill taxpayer info → W-2/1099 (from transcripts.json) → deductions → review.
+    3. **IP PIN** required for ANY prior-year e-file — confirm enrolled, else pause (irs.gov/identity-theft-fraud-scams/get-an-identity-protection-pin, ID.me).
+    4. Review/error-check; cross-check liability with irs-taxpayer-mcp if needed.
+    5. E-file federal (free). MN state $15.99/$17.99, or route state free (Cash App current yr / OLT prior yrs) if $0 desired.
+    6. E-file signature PIN = human gate per return.
+
+    ### 3. Old years (TY2022 and earlier) — paper, MAIL not fax
+
+    - IRS does NOT accept faxed 1040s; MN neither. Print → sign → mail.
+    1. Prepare on FreeTaxUSA (free, back to ~2015) → print PDF. Both spouses sign if MFJ.
+    2. MN: attach federal 1040 copy to M1 → **Minnesota Department of Revenue, Mail Station 0010, 600 N. Robert St., St. Paul, MN 55146-0010**.
+    3. Federal: address depends on form + payment/no-payment + state → fetch current from irs.gov "where to file" (obscura). Payments: check + Form 1040-V via REGULAR mail (private couriers delay payment processing).
+    4. Certified mail w/ return receipt = proof of filing date. Keep copies.
+
+    ## Pitfalls & reality checks
+
+    - **Refund claims expire 3 years after due date.** TY2022 refunds forfeited (~4/15/2026). TY2023 expires 4/15/2027.
+    - **Old years that owe**: FTF 5%/mo (cap 25%) + FTP 0.5%/mo + interest (fed + MN). Request **First-Time Penalty Abatement** (3 clean prior years) or reasonable cause.
+    - **ToS**: automating FreeTaxUSA/Cash App violates their ToS — account-ban risk, low for personal use, real. Low volume only.
+    - **Automation ceiling**: ID.me MFA, e-file attestation, the mailbox — human. Everything before is automatable.
+    - **MN amended returns**: e-filable from TY2025.
+    - **State returns**: FreeTaxUSA MN = $15.99/$17.99; Cash App free but current-year only; OLT free-state claim — verify at signup.
+    - Re-verify every season: the IRS free-filing program set changes drastically year to year.
+
+    ## Verification
+
+    - E-file: acceptance email / FreeTaxUSA status page (obscura snapshot).
+    - Paper: USPS tracking delivered; IRS paper processing 6-8+ weeks.
+    - Keep `transcripts.json` + filed PDFs in `/opt/data/tax/` (PVC-backed).

--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -318,6 +318,14 @@ hermes-agent:
           resources: false
           prompts: false
 
+      obscura:
+        command: "/usr/local/bin/obscura"
+        args: ["mcp", "--stealth"]
+        timeout: 120
+        tools:
+          resources: false
+          prompts: false
+
       google-workspace:
         command: "uvx"
         args: ["workspace-mcp", "--tool-tier", "complete"]
@@ -428,6 +436,9 @@ hermes-agent:
     - -c
     - |
       npm install -g @bitwarden/cli 2>&1
+      if [ ! -f /usr/local/bin/obscura ]; then
+        curl -sL https://github.com/h4ckf0r0day/obscura/releases/download/v0.2.0/obscura-aarch64-linux-stealth.tar.gz | tar -xz -C /usr/local/bin
+      fi
       exec /init hermes gateway run
   extraEnvFrom:
     - secretRef:

--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -423,6 +423,9 @@ hermes-agent:
     - name: k8s-gitops-context
       configMap:
         name: openagent-k8s-gitops-context
+    - name: skill-us-tax-filing-automation
+      configMap:
+        name: openagent-skill-us-tax-filing-automation
   extraVolumeMounts:
     - name: hermes-hooks
       mountPath: /opt/data/hooks/discord-session-link
@@ -430,6 +433,10 @@ hermes-agent:
     - name: k8s-gitops-context
       mountPath: /opt/data/memories/k8s-gitops-context.md
       subPath: k8s-gitops-context.md
+      readOnly: true
+    - name: skill-us-tax-filing-automation
+      mountPath: /opt/data/skills/us-tax-filing-automation/SKILL.md
+      subPath: us-tax-filing-automation.SKILL.md
       readOnly: true
   command:
     - sh

--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -436,6 +436,11 @@ hermes-agent:
     - -c
     - |
       npm install -g @bitwarden/cli 2>&1
+      if [ ! -f /usr/local/go/bin/go ]; then
+        curl -sL https://golang.org/dl/go1.22.4.linux-arm64.tar.gz | tar -xz -C /usr/local
+      fi
+      export PATH=/usr/local/go/bin:$PATH
+      cd /opt/data && go mod download
       if [ ! -f /usr/local/bin/obscura ]; then
         curl -sL https://github.com/h4ckf0r0day/obscura/releases/download/v0.2.0/obscura-aarch64-linux-stealth.tar.gz | tar -xz -C /usr/local/bin
       fi


### PR DESCRIPTION
## What
- **Skill ConfigMap**: `templates/skills/us-tax-filing-automation.yaml` (key `us-tax-filing-automation.SKILL.md`), mounted via subPath into `/opt/data/skills/us-tax-filing-automation/SKILL.md` (readOnly — updates via PR). Follows the opendesign skills-configmap precedent.
- **Assets versioned** under `services/helm/openagent/files/skills/us-tax-filing-automation/`:
  - `scripts/parse_wi_transcript.py` — IRS Wage & Income transcript (PDF/text) → structured JSON (W-2 + 1099 records). Tested on synthetic sample via `uv run --with pypdf`. Run with real transcript: `uv run --with pypdf parse_wi_transcript.py transcript.pdf -o transcripts.json`
  - `references/payroll-registry.json` — payroll (ADP/Gusto/Paychex/…) + brokerage (Fidelity/Schwab/…) provider registry for transcript cross-matching → dynamic portal lookup.

## Skill content
2026 free-filing landscape (Direct File discontinued; AGI > $89k → Free File ineligible; FreeTaxUSA free federal any income, current + prior years; prior-year e-file needs IRS IP PIN), obscura-driven filing workflow, TY2022+ paper workflow (mail, not fax — MN + IRS addresses), refund-window reality (3-yr expiry), penalty abatement.

## Caveats
- Skill SKILL.md is read-only once mounted (pod-side edits blocked; iterations via PR). scripts/ + references/ stay local (PVC) + versioned here.
- MFA (ID.me), e-file attestation, and the mailbox remain human gates.

## Tested
- Parser: synthetic W&I transcript → correct W-2 (wages/withholding/state) + 1099-INT/NEC extraction.