### PR TITLE
feat(tailscale): Tailscale Kubernetes Operator — kube-apiserver on the tailnet for CI

### DIFF
--- a/services/argocd-appset/values.yaml
+++ b/services/argocd-appset/values.yaml
@@ -105,6 +105,14 @@ services:
       - name: virtualServices.argocd.destination.port
         value: "80"
 
+  tailscale:
+    enable: true
+    syncWave: "2"
+    destNamespace: tailscale
+    dopplerConfig: "svc_tailscale"
+    syncOptions:
+      - CreateNamespace=true
+
   openagent:
     enable: true
     syncWave: "0"

--- a/services/helm/external-secrets/values.yaml
+++ b/services/helm/external-secrets/values.yaml
@@ -29,6 +29,9 @@ clusterSecretStores:
   svc_excalidash:
     project: devops
     config: svc_excalidash
+  svc_tailscale:
+    project: devops
+    config: svc_tailscale
   zurabase-dev:
     project: zurabase
     config: dev

--- a/services/helm/tailscale/Chart.yaml
+++ b/services/helm/tailscale/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: tailscale
-description: Tailscale Kubernetes Operator — exposes the kube-apiserver on the tailnet for CI/remote access
+description: Tailscale Kubernetes Operator
 type: application
 version: 0.1.0
 appVersion: 1.98.9

--- a/services/helm/tailscale/Chart.yaml
+++ b/services/helm/tailscale/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: tailscale
+description: Tailscale Kubernetes Operator — exposes the kube-apiserver on the tailnet for CI/remote access
+type: application
+version: 0.1.0
+appVersion: 1.98.9
+dependencies:
+  - name: tailscale-operator
+    version: 1.98.9
+    repository: https://pkgs.tailscale.com/helmcharts

--- a/services/helm/tailscale/README.md
+++ b/services/helm/tailscale/README.md
@@ -1,9 +1,7 @@
 # Tailscale Kubernetes Operator
 
-Dependency-override layer for the upstream `tailscale-operator` chart (v1.98.9,
-repo `https://pkgs.tailscale.com/helmcharts`). The operator joins this cluster to
-the tailnet and exposes the kube-apiserver as a tailnet service so the Terraform
-CI pipeline (GitHub Actions runners, off-cluster) can reach the API server.
+This operator joins this cluster to
+the tailnet for private access.
 
 ## What it does
 

--- a/services/helm/tailscale/README.md
+++ b/services/helm/tailscale/README.md
@@ -1,0 +1,31 @@
+# Tailscale Kubernetes Operator
+
+Dependency-override layer for the upstream `tailscale-operator` chart (v1.98.9,
+repo `https://pkgs.tailscale.com/helmcharts`). The operator joins this cluster to
+the tailnet and exposes the kube-apiserver as a tailnet service so the Terraform
+CI pipeline (GitHub Actions runners, off-cluster) can reach the API server.
+
+## What it does
+
+- `apiServerProxyConfig.mode: "true"` — in-process API server proxy (auth mode).
+  The operator creates a tailnet device + a `kubeconfig` ConfigMap in this
+  namespace with a ready-to-use kubeconfig (server `https://<name>.<tailnet>.ts.net`).
+- OAuth client auth — the operator mounts Secret `operator-oauth`
+  (files `client_id` + `client_secret`), pre-created by the Doppler ExternalSecret.
+
+## Prerequisites (user-side)
+
+1. Create a Tailscale **OAuth client** (login.tailscale.com → Settings → OAuth clients):
+   - Scopes: `devices` read+write
+   - Make it owner of tag `tag:k8s-operator`
+2. Doppler config `svc_tailscale` (project `devops`) with:
+   - `TAILSCALE_OAUTH_CLIENT_ID`
+   - `TAILSCALE_OAUTH_CLIENT_SECRET`
+3. Tailnet ACL: allow CI identities (the auth-key-tagged runner node) to reach the
+   apiserver proxy tag. With a default-allow tailnet, nothing to do.
+
+## CI usage
+
+The generated kubeconfig (ConfigMap `kubeconfig`, ns `tailscale`) is stored as
+Doppler `ci` → `KUBECONFIG` and written to `~/.kube/config` in the GitHub Actions
+workflows after `tailscale/github-action` connects the runner to the tailnet.

--- a/services/helm/tailscale/templates/externalsecret.yaml
+++ b/services/helm/tailscale/templates/externalsecret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: operator-oauth
+  namespace: tailscale
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: doppler-svc-tailscale
+  target:
+    name: operator-oauth
+    creationPolicy: Owner
+  data:
+    - secretKey: client_id
+      remoteRef:
+        key: TAILSCALE_OAUTH_CLIENT_ID
+    - secretKey: client_secret
+      remoteRef:
+        key: TAILSCALE_OAUTH_CLIENT_SECRET

--- a/services/helm/tailscale/values.yaml
+++ b/services/helm/tailscale/values.yaml
@@ -1,0 +1,21 @@
+# Local values — consumed by templates/externalsecret.yaml
+dopplerConfig: "svc_tailscale"
+
+# ── Upstream chart overrides (tailscale-operator v1.98.9 @ pkgs.tailscale.com/helmcharts) ──
+tailscale-operator:
+  # OAuth client auth. The chart mounts Secret `operator-oauth` (files client_id /
+  # client_secret) — pre-created by the Doppler ExternalSecret below. No static
+  # secrets in git. OAuth client must own tag:k8s-operator (see README).
+  oauth:
+    clientId: ""
+    clientSecret: ""
+
+  # Expose the kube-apiserver on the tailnet (auth mode → tailnet ACLs + generated
+  # kubeconfig ConfigMap in this namespace). CI / remote kubectl use it.
+  apiServerProxyConfig:
+    mode: "true"
+
+  operatorConfig:
+    hostname: "tailscale-operator"
+    nodeSelector:
+      kubernetes.io/os: linux

--- a/services/helm/tailscale/values.yaml
+++ b/services/helm/tailscale/values.yaml
@@ -1,17 +1,14 @@
-# Local values — consumed by templates/externalsecret.yaml
+
 dopplerConfig: "svc_tailscale"
 
-# ── Upstream chart overrides (tailscale-operator v1.98.9 @ pkgs.tailscale.com/helmcharts) ──
 tailscale-operator:
-  # OAuth client auth. The chart mounts Secret `operator-oauth` (files client_id /
-  # client_secret) — pre-created by the Doppler ExternalSecret below. No static
+  # OAuth client auth
   # secrets in git. OAuth client must own tag:k8s-operator (see README).
   oauth:
     clientId: ""
     clientSecret: ""
 
-  # Expose the kube-apiserver on the tailnet (auth mode → tailnet ACLs + generated
-  # kubeconfig ConfigMap in this namespace). CI / remote kubectl use it.
+  # Expose the kube-apiserver on the tailnet
   apiServerProxyConfig:
     mode: "true"
 


### PR DESCRIPTION
## Why

The Terraform pipeline (GitHub Actions, off-cluster) can't reach the k3s API server — the plan workflow fails before Terraform even runs. The Tailscale k8s operator joins the cluster to the tailnet and exposes the kube-apiserver as a tailnet service (auth mode), giving the CI runner a stable endpoint after `tailscale/github-action` connects it.

## What

- `services/helm/tailscale/` — dependency-override layer for `tailscale-operator` v1.98.9 (`pkgs.tailscale.com/helmcharts`)
- `apiServerProxyConfig.mode: "true"` → operator runs the in-process API server proxy + generates a `kubeconfig` ConfigMap
- `ExternalSecret operator-oauth` (sync-wave −1) ← Doppler `svc_tailscale` (`TAILSCALE_OAUTH_CLIENT_ID`/`_SECRET`) — chart mounts Secret `operator-oauth`; no static secrets in git
- `external-secrets`: `doppler-svc-tailscale` ClusterSecretStore
- appset: `tailscale` entry (wave 2, ns `tailscale`, CreateNamespace)

## User prereqs

1. Tailscale OAuth client (console): `devices` r/w scopes, owner of `tag:k8s-operator`
2. Doppler `devops/svc_tailscale`: `TAILSCALE_OAUTH_CLIENT_ID`, `TAILSCALE_OAUTH_CLIENT_SECRET`

Follow-up PR (after operator is live): extract the generated kubeconfig → Doppler `ci` `KUBECONFIG`; update workflows (drop AWS step, add tailscale/github-action + kubeconfig write).