### PR TITLE
refactor(excalidash): ExternalSecret always-dynamic + directly-fetchable secret name

### DIFF
--- a/apps/helm/excalidash/README.md
+++ b/apps/helm/excalidash/README.md
@@ -8,3 +8,16 @@ chart (v1.0.0, repo `https://charts.alekc.dev`).
 - Storage: 5Gi `local-path` PVC at `/app/prisma` (SQLite, single backend replica)
 - Routing: VirtualService `excalidash` in the istio chart (`enablePrivate: true` → `require-cf-access-excalidash` DENY policy)
 - Backend env: `FRONTEND_URL`, `TRUST_PROXY=1`, `ENFORCE_HTTPS_REDIRECT=false` (edge TLS), `UPDATE_CHECK_OUTBOUND=false`
+
+
+## Secrets convention (ES evolution 2026-08-09)
+
+- **Always dynamic**: the ExternalSecret uses `dataFrom` find-all (`regexp: ".*"`) —
+  every key in Doppler `svc_excalidash` lands in the k8s Secret automatically.
+  No per-key `data:` list to maintain; new Doppler secrets just work.
+- **Directly-fetchable name**: the chart secret key is `secrets` (not
+  `excalidash-secrets`) so the rendered object is `<fullname>-<key>` =
+  `excalidash-secrets` — predictable, no double prefix. The ES target matches it.
+- Exception to the dynamic rule: consumers that require fixed key/file names
+  (e.g. Tailscale operator-oauth `client_id`/`client_secret`) keep explicit
+  `data:` mapping.

--- a/apps/helm/excalidash/templates/externalsecret.yaml
+++ b/apps/helm/excalidash/templates/externalsecret.yaml
@@ -11,14 +11,14 @@ spec:
     kind: ClusterSecretStore
     name: doppler-svc-excalidash
   target:
-    # Chart renders envFrom secretRef as "<fullname>-<key>" -> excalidash-excalidash-secrets.
-    # Merge policy writes Doppler values into the chart-managed secret the app actually reads.
-    name: excalidash-excalidash-secrets
+    # Chart renders envFrom secretRef as "<fullname>-<key>" -> key `secrets`
+    # gives the clean, directly-fetchable name `excalidash-secrets`.
+    # Merge policy writes Doppler values into the chart-managed secret.
+    name: excalidash-secrets
     creationPolicy: Merge
-  data:
-    - secretKey: JWT_SECRET
-      remoteRef:
-        key: JWT_SECRET
-    - secretKey: CSRF_SECRET
-      remoteRef:
-        key: CSRF_SECRET
+  # Always dynamic: fetch ALL keys from the Doppler config, so new secrets
+  # added in Doppler flow in without a chart change.
+  dataFrom:
+    - find:
+        name:
+          regexp: ".*"

--- a/apps/helm/excalidash/values.yaml
+++ b/apps/helm/excalidash/values.yaml
@@ -19,10 +19,13 @@ excalidash:
           main:
             mountPath: /app/prisma
 
-  # Chart-managed secret — auto-generates JWT/CSRF as boot fallback.
-  # Doppler ExternalSecret (creationPolicy: Merge) overwrites with real values.
+  # Chart-managed secret — key `secrets` renders the Secret object as
+  # `excalidash-secrets` (<fullname>-<key>), so the name is directly
+  # fetchable/predictable. Auto-generates JWT/CSRF as boot fallback;
+  # the Doppler ExternalSecret (creationPolicy: Merge, dataFrom find-all)
+  # overwrites with real values.
   secret:
-    excalidash-secrets:
+    secrets:
       enabled: true
       data:
         JWT_SECRET: ""
@@ -50,4 +53,4 @@ excalidash:
               ENFORCE_HTTPS_REDIRECT: "false"
             envFrom:
               - secretRef:
-                  name: excalidash-secrets
+                  name: secrets


### PR DESCRIPTION
## ExternalSecrets evolution (user request)

- **Always dynamic**: `dataFrom: [{find: {name: {regexp: ".*"}}}]` — all keys from Doppler `svc_excalidash` flow into the k8s Secret automatically; no per-key list to maintain.
- **Rename for direct fetch**: chart secret key `excalidash-secrets` → `secrets` so the rendered object is `excalidash-secrets` (was `excalidash-excalidash-secrets`). ES target matches. Predictable `kubectl get secret excalidash-secrets -n excalidash`.
- README documents the convention + the fixed-key exception (tailscale operator-oauth).

Post-merge: update the standalone excalidash Application's ignoreDifferences to the new secret name, sync, verify pods.