### PR TITLE
fix(external-secrets): ServerSideApply sync option (ESO CRD annotation >256KB)

### DIFF
--- a/services/argocd-appset/values.yaml
+++ b/services/argocd-appset/values.yaml
@@ -53,6 +53,9 @@ services:
     retryMaxDuration: 3m
     syncOptions:
       - CreateNamespace=true
+      # SSA avoids the 256KB last-applied annotation on the huge ESO CRDs
+      # (SyncError: metadata.annotations: Too long). Required since 2026-08-09.
+      - ServerSideApply=true
     ignoreDifferences:
       - group: ""
         kind: Secret


### PR DESCRIPTION
## Blocker

`external-secrets` app SyncError since 2026-08-09 07:06: client-side apply writes the `kubectl.kubernetes.io/last-applied-configuration` annotation on the huge `clustersecretstores`/`secretstores` CRDs and the total annotation payload exceeds the API's 262144-byte limit → `metadata.annotations: Too long`. This blocked creation of the `doppler-svc-tailscale` store (and thus the tailscale operator).

## Fix

Add `ServerSideApply=true` sync option to the externalSecrets appset entry — SSA doesn't write the last-applied annotation, immune to the size limit.

Live-applied in parallel (external-secrets Application already has the option); this makes it durable through the appset.