### PR TITLE
feat(openagent): install Doppler CLI via hermes-agent chart startup (like go/obscura)

### DIFF
--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -446,10 +446,22 @@ hermes-agent:
       if [ ! -f /usr/local/go/bin/go ]; then
         curl -sL https://golang.org/dl/go1.22.4.linux-arm64.tar.gz | tar -xz -C /usr/local
       fi
-      export PATH=/usr/local/go/bin:$PATH
+      export PATH=/usr/local/go/bin:/opt/data/bin:$PATH
       cd /opt/data && go mod download
       if [ ! -f /usr/local/bin/obscura ]; then
         curl -sL https://github.com/h4ckf0r0day/obscura/releases/download/v0.2.0/obscura-aarch64-linux-stealth.tar.gz | tar -xz -C /usr/local/bin
+      fi
+      # Doppler CLI — same binary endpoint the official install script uses
+      # (cli.doppler.com/download). gpgv signature verify skipped: container
+      # runs uid 10000 w/o sudo, so gnupg can't be installed here. Installs to
+      # the PVC /opt/data/bin (user-writable, survives restarts).
+      if [ ! -x /opt/data/bin/doppler ]; then
+        mkdir -p /opt/data/bin
+        DOP_ARCH=$(uname -m | sed 's/aarch64/arm64/; s/x86_64/amd64/')
+        curl -fsSL --retry 3 "https://cli.doppler.com/download?os=linux&arch=${DOP_ARCH}&format=tar" -o /tmp/doppler.tgz \
+          && tar -xzf /tmp/doppler.tgz -C /opt/data/bin doppler \
+          && chmod +x /opt/data/bin/doppler \
+          || rm -f /opt/data/bin/doppler
       fi
       exec /init hermes gateway run
   extraEnvFrom:
@@ -494,3 +506,4 @@ litellmVirtualService:
 # ── VPA ────────────────────────────────────────────────────────────
 vpa:
   enabled: true
+


### PR DESCRIPTION
## What
Adds the **Doppler CLI** to the hermes-agent startup `command` block in `services/helm/openagent/values.yaml` — the same mechanism that provisions bitwarden/go/obscura.

## How
- Downloads from the **official binary endpoint** `cli.doppler.com/download?os=linux&arch=&format=tar` (the exact URL the official install script uses)
- Installs into `/opt/data/bin` on the agent's PVC — user-writable (container runs uid 10000, no sudo), survives restarts
- Prepends `/opt/data/bin` to `PATH` so `doppler` is on the agent's path
- Idempotent: `if [ ! -x /opt/data/bin/doppler ]` guard, `|| rm -f` cleanup on partial download

## gpg note
The official script hard-requires `gpgv` (clean_exit 3) for signature verification. This container can't install gnupg (uid 10000, no sudo), so verification is skipped here — the download is HTTPS from `cli.doppler.com` itself. The gpg-verified `sudo` path remains available on root-capable hosts via the official script (`cli.doppler.com/install.sh`), documented in devops_Terraform `.useful-devops-scripts/doppler-cli/` (PR #5, superseded by this chart-based install).
