### PR TITLE
feat(openagent): LiteLLM pass-through endpoint for claude-proxy

### DIFF
--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -47,6 +47,17 @@ litellm:
   proxy_config:
     general_settings:
       master_key: os.environ/LITELLM_MASTER_KEY
+      # Raw pass-through to claude-pipe (claude-proxy). Requests to
+      # /claude-pipe/<path> are forwarded byte-for-byte to the upstream, so
+      # Anthropic /v1/messages and OpenAI /v1/chat/completions both work
+      # without LiteLLM format conversion. NOTE: OSS pass-through routes skip
+      # LiteLLM key auth (Enterprise-only) — protect via Cloudflare Access.
+      pass_through_endpoints:
+        - path: "/claude-pipe"
+          target: "http://claude-proxy.openagent.svc.cluster.local:4523"
+          include_subpath: true
+          forward_headers: true
+          timeout: 300
     litellm_settings:
       drop_params: true
     router_settings:


### PR DESCRIPTION
## What
Adds a raw pass-through endpoint to LiteLLM for claude-proxy (claude-pipe):

```yaml
general_settings:
  pass_through_endpoints:
    - path: "/claude-pipe"
      target: "http://claude-proxy.openagent.svc.cluster.local:4523"
      include_subpath: true
      forward_headers: true
      timeout: 300
```

Requests to /claude-pipe/v1/messages (Anthropic) and /claude-pipe/v1/chat/completions (OpenAI) now forward byte-for-byte to claude-pipe - no Anthropic<->OpenAI format conversion inside LiteLLM. Model aliasing, fallbacks, rpm caps still live on the existing model_list entries (hybrid; nothing removed yet).

## Why
Current chain double-converts: Anthropic SDK clients -> LiteLLM (Anthropic->OpenAI) -> claude-pipe (OpenAI->Anthropic). Pass-through kills the round-trip for compat-sensitive clients (tool calls, thinking, streaming, cache_control). Also removes those models from LiteLLM health-probe cycles (probe-driven subscription quota burn).

## Test plan
1. Merge/sync, restart litellm (file-based routing, no DB).
2. From litellm pod: POST /claude-pipe/v1/messages and /claude-pipe/v1/chat/completions (stream + non-stream) - expect raw claude-pipe responses.
3. Via https://litellm.maklab.net/claude-pipe/... (behind Cloudflare Access).
4. Compare playground results for claude/sonnet-5 (model_list path) vs pass-through.

## Notes / known limitations
- BLOCKER: claude subscription OAuth is dead - refresh token revoked (invalid_grant), claude -p exits 1, all claude model_list entries currently 500. Re-auth (claude auth login) needed before end-to-end test can pass.
- OSS pass-through routes skip LiteLLM key auth (Enterprise-only) - route is open on the service port; public exposure protected by Cloudflare Access on litellm.maklab.net.
- No rpm caps / fallbacks on pass-through traffic (by design; responses-proxy chain unaffected).
- helm-docs table not regenerated (no helm-docs in this env).
- Follow-up PR (after test): drop claude-proxy sed patches (aliases, /v1/responses injection), remove responses-config, switch client model names to native claude-pipe names.