### PR TITLE
fix(openagent): add missing claude-credentials PVC template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,12 @@
 .DS_Store
 *.log
 test-gpu.yaml
-**charts/
+**/charts/*
+!services/helm/openagent/charts/headroom/
 !services/helm/openagent/charts/headroom/**
+!services/helm/openagent/charts/hermes-workspace/
 !services/helm/openagent/charts/hermes-workspace/**
+!services/helm/openagent/charts/claude-proxy/
 !services/helm/openagent/charts/claude-proxy/**
 **Chart.lock
 .devbox/

--- a/services/helm/openagent/charts/claude-proxy/templates/pvc.yaml
+++ b/services/helm/openagent/charts/claude-proxy/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.enabled .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: claude-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "claude-proxy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: claude-proxy
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.persistence.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}


### PR DESCRIPTION
## What happened
PR #61 (credential persistence) updated the claude-proxy Deployment to reference `claimName: claude-credentials` and added a seed-only init container, but the **pvc.yaml template never landed in the commit** — the new pod was stuck `Pending` with `persistentvolumeclaim "claude-credentials" not found`.

## Root cause
`.gitignore` had `**charts/` which excludes the charts directory ITSELF. The negation `!services/helm/openagent/charts/claude-proxy/**` was a no-op for NEW files: git does not re-include files under an excluded parent directory. The existing claude-proxy templates were only tracked because they predate the ignore rule. `pvc.yaml` (new) was silently ignored by `git add -A`.

## Fix
- `.gitignore`: `**charts/` → `**/charts/*` (ignore contents, not the dir), plus explicit re-includes of the directory before its contents (`!.../claude-proxy/` + `!.../claude-proxy/**`).
- Adds `templates/pvc.yaml`: RWO local-path PVC, 100Mi, `claude-credentials` (matches the deployment's claimName; seeded by the seed-credentials init container on first boot).

## Verification
- `git check-ignore` now passes pvc.yaml through to the negation (trackable); `git status` shows it as untracked instead of invisible.
- After merge + ArgoCD sync: PVC binds, claude-proxy pod schedules, seed init copies fresh credentials from the secret.

## Notes
- This is the missing half of #61; the deployment already references the claim, so no deployment change needed here.