### PR TITLE
CI: connect to local k3s via Tailscale operator

### DIFF
--- a/.github/workflows/helm_lint-test.yaml
+++ b/.github/workflows/helm_lint-test.yaml
@@ -34,10 +34,27 @@ jobs:
           doppler-token: ${{ secrets.DOPPLER_TOKEN }}
           inject-env-vars: true
 
+      # Cluster connectivity: local k3s exposed on the tailnet via the
+      # Tailscale k8s operator (apiServerProxyConfig.mode: "true").
+      # Runner joins as an ephemeral node (tag:k8s from the auth key);
+      # kubeconfig is generated client-side — v1.98+ does NOT drop a
+      # kubeconfig ConfigMap into the operator namespace.
+      - name: Connect to Tailscale (local k3s)
+        uses: tailscale/github-action@main
+        with:
+          authkey: ${{ env.TAILSCALE_AUTH_KEY }}
+
+      - name: Configure kubectl via Tailscale apiserver proxy
+        run: |
+          tailscale configure kubeconfig ${{ env.TAILSCALE_PROXY_HOST }}
+          kubectl config current-context
+
       - name: Grab File changes
         id: changed-files
         uses: tj-actions/changed-files@main
 
+      # GKE auth commented out — live target is the local k3s cluster
+      # (exposed via the Tailscale k8s operator, not GKE).
       # - name: Authenticate to Google Cloud
       #   uses: google-github-actions/auth@v2
       #   with:
@@ -61,19 +78,19 @@ jobs:
         run: |
           .useful-scripts/validate_litellm_config.sh
 
-      # - name: Run Dry-Run
-      #   env:
-      #     changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
-      #   run: |
-      #     # Confirm k8s setup and connection
-      #     if ! cluster_config=$(kubectl config current-context 2>&1); then
-      #         echo "::error::$cluster_config"
-      #         exit 1
-      #     fi
+      - name: Run Dry-Run
+        env:
+          changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          # Confirm k8s setup and connection
+          if ! cluster_config=$(kubectl config current-context 2>&1); then
+              echo "::error::$cluster_config"
+              exit 1
+          fi
 
-      #     if ! cluster_connection=$(kubectl cluster-info 2>&1); then
-      #         echo "::error::$cluster_connection"
-      #         exit 1
-      #     fi
+          if ! cluster_connection=$(kubectl cluster-info 2>&1); then
+              echo "::error::$cluster_connection"
+              exit 1
+          fi
 
-      #     echo "Testing out changes on: $cluster_config" && ./ct_check.sh "$changed_files" install
+          echo "Testing out changes on: $cluster_config" && ./ct_check.sh "$changed_files" install

--- a/.github/workflows/helm_lint-test.yaml
+++ b/.github/workflows/helm_lint-test.yaml
@@ -1,6 +1,4 @@
-# NOTE: keep the name static — the `github` context is NOT available in the
-# workflow `name:` field; an expression here makes GitHub reject the file
-# (instant failure run, zero jobs).
+# Static name: `github` context is invalid in workflow name:
 name: Helm - Lint/Test
 
 on:
@@ -39,17 +37,13 @@ jobs:
           doppler-config: ci
           inject-env-vars: true
 
-      # Cluster connectivity: local k3s exposed on the tailnet via the
-      # Tailscale k8s operator (apiServerProxyConfig.mode: "true").
-      # Runner joins as an ephemeral node (tag:k8s from the auth key);
-      # kubeconfig is generated client-side — v1.98+ does NOT drop a
-      # kubeconfig ConfigMap into the operator namespace.
-      - name: Connect to Tailscale (local k3s)
+      # Tailnet k8s access: join tailnet (tag:k8s) + client-side kubeconfig
+      - name: Connect to Tailscale
         uses: tailscale/github-action@main
         with:
           authkey: ${{ env.TAILSCALE_AUTH_KEY }}
 
-      - name: Configure kubectl via Tailscale apiserver proxy
+      - name: Configure kubectl
         run: |
           tailscale configure kubeconfig ${{ env.TAILSCALE_PROXY_HOST }}
           kubectl config current-context
@@ -58,8 +52,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@main
 
-      # GKE auth commented out — live target is the local k3s cluster
-      # (exposed via the Tailscale k8s operator, not GKE).
+      # GKE auth disabled — local k3s via Tailscale
       # - name: Authenticate to Google Cloud
       #   uses: google-github-actions/auth@v2
       #   with:

--- a/.github/workflows/helm_lint-test.yaml
+++ b/.github/workflows/helm_lint-test.yaml
@@ -35,6 +35,8 @@ jobs:
         uses: dopplerhq/secrets-fetch-action@main
         with:
           doppler-token: ${{ secrets.DOPPLER_TOKEN }}
+          doppler-project: devops
+          doppler-config: ci
           inject-env-vars: true
 
       # Cluster connectivity: local k3s exposed on the tailnet via the

--- a/.github/workflows/helm_lint-test.yaml
+++ b/.github/workflows/helm_lint-test.yaml
@@ -1,4 +1,7 @@
-name: Helm - Lint/Test - ${{ github.event_name == 'pull_request' && format('PR-#{0}', github.event.number) || 'On-demand' }}
+# NOTE: keep the name static — the `github` context is NOT available in the
+# workflow `name:` field; an expression here makes GitHub reject the file
+# (instant failure run, zero jobs).
+name: Helm - Lint/Test
 
 on:
   workflow_dispatch:  # manual run option
@@ -16,7 +19,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           check-latest: true

--- a/services/helm/tailscale/templates/ci-rbac.yaml
+++ b/services/helm/tailscale/templates/ci-rbac.yaml
@@ -1,0 +1,30 @@
+# RBAC for tailnet CI identities.
+#
+# GitHub Actions runners join the tailnet via TAILSCALE_AUTH_KEY (Doppler
+# devops/ci; reusable + ephemeral auth key tagged tag:k8s) and reach the
+# kube-apiserver through the Tailscale operator's apiserver proxy
+# (apiServerProxyConfig.mode: "true"). In auth mode the proxy impersonates
+# the tailnet identity into the cluster, so the CI identity must be bound
+# to permissions for chart install tests (gke_GitOps) and Terraform
+# providers (devops_Terraform) to operate.
+#
+# NOTE: verify the impersonated user/group on the first CI run — a Forbidden
+# error names the exact identity. If it differs from tag:k8s, tighten this
+# binding accordingly.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ci-tailscale-k8s-admin
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: Group
+    name: tag:k8s
+    apiGroup: rbac.authorization.k8s.io
+  - kind: User
+    name: tag:k8s
+    apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## What
Local k3s cluster is now exposed on the tailnet via the Tailscale k8s operator (`tailscale-operator.tail2354a3.ts.net`). Wire CI to it so chart install tests can reach the cluster.

## Changes
- **helm_lint-test.yaml**: add `tailscale/github-action` (authkey from Doppler `devops/ci` `TAILSCALE_AUTH_KEY`, tag `tag:k8s`) + client-side kubeconfig (`tailscale configure kubeconfig` — v1.98+ no longer drops a ConfigMap)
- Re-enable the Dry-Run step (kubectl cluster-info gate + `ct_check.sh install`)
- **New** `services/helm/tailscale/templates/ci-rbac.yaml`: ClusterRoleBinding cluster-admin → CI identity (`tag:k8s` user+group; the auth-mode proxy impersonates tailnet identity). **Verification**: if the first run shows a different impersonated user/group in a Forbidden error, adjust the binding.

## Depends on
- Doppler `devops/ci`: `TAILSCALE_AUTH_KEY` (reusable+ephemeral, tag:k8s), `TAILSCALE_PROXY_HOST` — added

GKE auth steps remain commented out (local k3s is the live target).