### PR TITLE
feat(pg-main): centralized StackGres cluster with R2 backups

### DIFF
--- a/services/argocd-appset/values.yaml
+++ b/services/argocd-appset/values.yaml
@@ -240,7 +240,7 @@ services:
     enable: true
     syncWave: "5"
     destNamespace: data
-    dopplerConfig: "svc_pg"
+    dopplerConfig: "svc_postgres_operator"
     retryLimit: 5
     retryMaxDuration: 3m
     syncOptions:

--- a/services/argocd-appset/values.yaml
+++ b/services/argocd-appset/values.yaml
@@ -234,6 +234,43 @@ services:
           - .spec.data[].remoteRef.nullBytePolicy
     dopplerConfig: "svc_postgres_operator"
 
+  # Centralized PostgreSQL — shared SGCluster (data ns), per-service DBs via users list.
+  # Requires Doppler config svc_pg (R2 keys + per-service PG passwords) — user-side prereq.
+  pgMain:
+    enable: true
+    syncWave: "5"
+    destNamespace: data
+    dopplerConfig: "svc_pg"
+    retryLimit: 5
+    retryMaxDuration: 3m
+    syncOptions:
+      - CreateNamespace=true
+      - SyncTimeoutSeconds=300
+    ignoreDifferences:
+      - group: stackgres.io
+        kind: SGPostgresConfig
+        name: pg-main-config
+        namespace: data
+        jsonPointers:
+          - /spec/postgresql.conf
+      - group: stackgres.io
+        kind: SGCluster
+        name: pg-main
+        namespace: data
+        jsonPointers:
+          - /spec/configurations/observability
+          - /spec/pods/disableEnvoy
+          - /spec/pods/disablePostgresUtil
+          - /spec/pods/managementPolicy
+          - /spec/pods/updateStrategy
+          - /spec/postgres/flavor
+          - /spec/postgres/ssl
+          - /spec/postgresServices
+          - /spec/replication
+          - /spec/sgInstanceProfile
+          - /spec/users
+          - /spec/managedSql
+
   # Wave 5 — General services
   kubePrometheusStack:
     enable: true

--- a/services/helm/pg-main/Chart.yaml
+++ b/services/helm/pg-main/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: pg-main
+description: Centralized PostgreSQL cluster (StackGres) — shared database for all services
+type: application
+version: 0.1.0
+appVersion: "18"

--- a/services/helm/pg-main/README.md
+++ b/services/helm/pg-main/README.md
@@ -3,9 +3,20 @@
 One shared StackGres cluster (`pg-main`, namespace `data`) hosting a database + role per service,
 replacing per-service SGClusters (e.g. `openagent-pg`).
 
+## Ownership model (user-directed: "the db should be in gitops")
+
+- **DB definition = gitops** (`gke_GitOps`, ArgoCD-managed): cluster, per-service DBs/roles, and
+  backup schedules all live in this chart + `services/argocd-appset/values.yaml`. No Terraform, no
+  ad-hoc kubectl for DB resources.
+- **Terraform (`devops_Terraform`)** only provisions cloud-side: the R2 bucket (`stackgres-pg-main`)
+  and Doppler secret population.
+- **Secrets** (per-service passwords, R2 keys) live in Doppler config `svc_postgres_operator`
+  (devops project) → ExternalSecret `pg-secrets` (wave -3) → cluster.
+- Per-service onboarding = one gitops PR (users entry + Doppler password). Nothing else.
+
 ## Onboarding a new service `<svc>`
 
-1. **Doppler** (`devops` project, config `svc_pg`): add `<SVC>_PG_PASSWORD` (generated once, strong).
+1. **Doppler** (`devops` project, config `svc_postgres_operator`): add `<SVC>_PG_PASSWORD` (generated once, strong).
 2. **values.yaml** — add to `postgres.users`:
    ```yaml
    users:

--- a/services/helm/pg-main/README.md
+++ b/services/helm/pg-main/README.md
@@ -1,0 +1,34 @@
+# pg-main — centralized PostgreSQL (StackGres)
+
+One shared StackGres cluster (`pg-main`, namespace `data`) hosting a database + role per service,
+replacing per-service SGClusters (e.g. `openagent-pg`).
+
+## Onboarding a new service `<svc>`
+
+1. **Doppler** (`devops` project, config `svc_pg`): add `<SVC>_PG_PASSWORD` (generated once, strong).
+2. **values.yaml** — add to `postgres.users`:
+   ```yaml
+   users:
+     - name: <svc>
+       passwordKey: <SVC>_PG_PASSWORD
+       databases: [<svc>]
+   ```
+3. **Authz** (when `authz.enabled: true`): add `cluster.local/ns/<svc>/sa/<svc-sa>` to `authz.principals`.
+4. **App env**:
+   `DATABASE_URL: postgresql://<svc>:<pw>@pg-main-primary.data.svc.cluster.local:5432/<svc>`
+   (or `pg-main.data.svc.cluster.local` — bare name resolves to primary).
+5. Verify: `psql` from the consumer pod; cross-namespace non-listed SAs denied once authz is on.
+
+## Backups
+
+- Weekly base backup + continuous WAL archiving to Cloudflare R2 (`sgobjectstorage` v1beta1, s3Compatible).
+- Manual backup: create an `SGBackup` referencing `pg-main-storage`, or run
+  `kubectl exec -n data pg-main-0 -- /opt/stackgres/bin/pgbackrest ...` for ad-hoc restores.
+- Restore drill: create a throwaway SGCluster with `spec.initialData.restore` pointing at the backup.
+
+## Known limitations
+
+- `authz` disabled by default: the StackGres operator (non-ambient `postgres-operator` ns) must reach
+  the cluster; principal-based policies would block non-mesh management traffic. Revisit when
+  hardening the mesh.
+- SGBackupConfig CRD is absent in this StackGres version — schedules are inline in `SGCluster.spec.backups`.

--- a/services/helm/pg-main/templates/authorizationpolicy.yaml
+++ b/services/helm/pg-main/templates/authorizationpolicy.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.authz.enabled }}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ .Values.postgres.clusterName }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  selector:
+    matchLabels:
+      stackgres.io/cluster: {{ .Values.postgres.clusterName }}
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              {{- range .Values.authz.principals }}
+              - {{ . | quote }}
+              {{- end }}
+{{- end }}

--- a/services/helm/pg-main/templates/externalsecret.yaml
+++ b/services/helm/pg-main/templates/externalsecret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pg-secrets
+  namespace: {{ .Values.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  refreshInterval: 24h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ required "dopplerConfig is required (appset injects it)" .Values.dopplerConfig }}
+  target:
+    name: pg-secrets
+    creationPolicy: Owner
+  dataFrom:
+    - find:
+        name:
+          regexp: ".*"

--- a/services/helm/pg-main/templates/sgcluster.yaml
+++ b/services/helm/pg-main/templates/sgcluster.yaml
@@ -1,0 +1,48 @@
+apiVersion: stackgres.io/v1
+kind: SGCluster
+metadata:
+  name: {{ .Values.postgres.clusterName }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  instances: {{ .Values.postgres.instances }}
+  postgres:
+    version: {{ .Values.postgres.version | quote }}
+  profile: {{ .Values.postgres.profile | quote }}
+  pods:
+    persistentVolume:
+      size: {{ .Values.postgres.storage }}
+      {{- if .Values.storageClass }}
+      storageClass: {{ .Values.storageClass }}
+      {{- end }}
+    disableMetricsExporter: {{ .Values.postgres.disableMetricsExporter }}
+    disableConnectionPooling: {{ .Values.postgres.disableConnectionPooling }}
+  configurations:
+    sgPostgresConfig: {{ .Values.postgres.configName }}
+    sgPoolingConfig: {{ .Values.postgres.poolingConfigName }}
+  managedSql:
+    scripts:
+      - id: 0
+        sgScript: {{ .Values.postgres.scriptName }}
+  users:
+    {{- range .Values.postgres.users }}
+    - name: {{ .name }}
+      password:
+        secretKeyRef:
+          name: pg-secrets
+          key: {{ .passwordKey }}
+      login: true
+      inherit: true
+      databases:
+        {{- range .databases }}
+        - name: {{ . }}
+          owner: true
+        {{- end }}
+    {{- end }}
+  {{- if .Values.backups.enabled }}
+  backups:
+    - cronSchedule: {{ .Values.backups.cronSchedule | quote }}
+      retention: {{ .Values.backups.retention }}
+      sgObjectStorage: {{ .Values.postgres.clusterName }}-storage
+  {{- end }}

--- a/services/helm/pg-main/templates/sgobjectstorage.yaml
+++ b/services/helm/pg-main/templates/sgobjectstorage.yaml
@@ -1,0 +1,23 @@
+apiVersion: stackgres.io/v1beta1
+kind: SGObjectStorage
+metadata:
+  name: {{ .Values.postgres.clusterName }}-storage
+  namespace: {{ .Values.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  type: s3Compatible
+  s3Compatible:
+    bucket: {{ .Values.backups.bucket }}
+    region: {{ .Values.backups.region }}
+    endpoint: {{ .Values.backups.endpoint }}
+    enablePathStyleAddressing: true
+    path: {{ .Values.backups.path }}
+    awsCredentials:
+      secretKeySelectors:
+        accessKeyId:
+          name: pg-secrets
+          key: R2_ACCESS_KEY_ID
+        secretAccessKey:
+          name: pg-secrets
+          key: R2_SECRET_ACCESS_KEY

--- a/services/helm/pg-main/templates/sgpoolingconfig.yaml
+++ b/services/helm/pg-main/templates/sgpoolingconfig.yaml
@@ -1,0 +1,13 @@
+apiVersion: stackgres.io/v1
+kind: SGPoolingConfig
+metadata:
+  name: {{ .Values.postgres.poolingConfigName }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  pgBouncer:
+    pgbouncer.ini:
+      pgbouncer:
+        pool_mode: transaction
+        max_client_conn: "100"

--- a/services/helm/pg-main/templates/sgpostgresconfig.yaml
+++ b/services/helm/pg-main/templates/sgpostgresconfig.yaml
@@ -1,0 +1,11 @@
+apiVersion: stackgres.io/v1
+kind: SGPostgresConfig
+metadata:
+  name: {{ .Values.postgres.configName }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  postgresVersion: {{ .Values.postgres.version | quote }}
+  postgresql.conf:
+    timezone: "America/Chicago"

--- a/services/helm/pg-main/templates/sgscript.yaml
+++ b/services/helm/pg-main/templates/sgscript.yaml
@@ -1,0 +1,21 @@
+apiVersion: stackgres.io/v1
+kind: SGScript
+metadata:
+  name: {{ .Values.postgres.scriptName }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  scripts:
+    {{- range $u := .Values.postgres.users }}
+    {{- range $db := $u.databases }}
+    - name: create-{{ $db }}-db
+      script: |
+        DO $$
+        BEGIN
+          IF NOT EXISTS (SELECT 1 FROM pg_database WHERE datname = '{{ $db }}') THEN
+            CREATE DATABASE {{ $db }} OWNER {{ $u.name }};
+          END IF;
+        END $$;
+    {{- end }}
+    {{- end }}

--- a/services/helm/pg-main/values.yaml
+++ b/services/helm/pg-main/values.yaml
@@ -1,0 +1,46 @@
+# Injected by ArgoCD appset (services/argocd-appset) — ClusterSecretStore name
+dopplerConfig: "svc_pg"
+
+namespace: data
+storageClass: local-path
+
+postgres:
+  clusterName: pg-main
+  configName: pg-main-config
+  poolingConfigName: pg-main-pooling
+  scriptName: pg-main-init
+  instances: 1
+  storage: 20Gi
+  version: "18"
+  profile: "development"
+  disableMetricsExporter: true
+  disableConnectionPooling: true   # matches openagent convention; revisit under connection pressure
+  # Per-service DB users. Each entry provisions a least-privilege role + DB(s) via SGCluster.users
+  # (password from Doppler config svc_pg -> ExternalSecret pg-secrets, key = passwordKey)
+  # + SGScript DB creation (openagent pattern). Add a service here + its Doppler key + authz principal.
+  users: []
+  # users:
+  #   - name: plane
+  #     passwordKey: PLANE_PG_PASSWORD
+  #     databases: [plane]
+
+backups:
+  enabled: true
+  cronSchedule: "0 2 * * 0"        # weekly base backup; WAL archiving is continuous
+  retention: 4                     # keep 4 base backups
+  bucket: stackgres-pg-main
+  endpoint: https://<CF_ACCOUNT_ID>.r2.cloudflarestorage.com   # TODO: set real R2 account id
+  region: auto
+  path: pg-main
+
+# Istio AuthorizationPolicy principals (workload identities allowed to reach the DB).
+# DISABLED by default: enforcing requires the `data` namespace to be labeled
+# istio.io/dataplane-mode: ambient AND the StackGres operator's management traffic to be
+# allowed (operator ns postgres-operator is NOT ambient; principal rules would block
+# non-mesh operator traffic -> cluster unmanageable). Enable only after testing
+# operator<->cluster connectivity under the policy.
+authz:
+  enabled: false
+  principals: []
+  # principals:
+  #   - "cluster.local/ns/plane/sa/plane-app"

--- a/services/helm/pg-main/values.yaml
+++ b/services/helm/pg-main/values.yaml
@@ -1,5 +1,5 @@
 # Injected by ArgoCD appset (services/argocd-appset) — ClusterSecretStore name
-dopplerConfig: "svc_pg"
+dopplerConfig: "svc_postgres_operator"
 
 namespace: data
 storageClass: local-path

--- a/services/helm/pg-main/values.yaml
+++ b/services/helm/pg-main/values.yaml
@@ -29,7 +29,7 @@ backups:
   cronSchedule: "0 2 * * 0"        # weekly base backup; WAL archiving is continuous
   retention: 4                     # keep 4 base backups
   bucket: stackgres-pg-main
-  endpoint: https://<CF_ACCOUNT_ID>.r2.cloudflarestorage.com   # TODO: set real R2 account id
+  endpoint: https://f8caac5c12d315d3690fd6df74cacdb9.r2.cloudflarestorage.com
   region: auto
   path: pg-main
 


### PR DESCRIPTION
## Centralized PostgreSQL — pg-main (StackGres)

### Motivation
Replace per-service StackGres clusters (currently: `openagent-pg` in `openagent` ns) with ONE shared
cluster (`pg-main`, namespace `data`) where each service gets its own database + least-privilege role.
First consumer: Plane (greenfield, queued). `openagent-pg` migrates afterward (in-scope).

### What this PR does
- **`services/helm/pg-main/`** — new self-hosted chart (openagent `templates/db/*` convention):
  - `ExternalSecret` `pg-secrets` (wave -3) ← Doppler `svc_pg` (find-all)
  - `SGPostgresConfig` (PG 18) / `SGPoolingConfig` (pgbouncer) / `SGScript` (DB creation) — wave -1
  - `SGCluster` `pg-main`: 1 instance, 20Gi local-path, `profile: development`, per-service
    `users:` list (password via `pg-secrets`), **inline backups** (weekly base + WAL, retention 4)
  - `SGObjectStorage` (v1beta1, `s3Compatible`) → Cloudflare R2, creds via `pg-secrets`
  - `AuthorizationPolicy` — **disabled by default** (`authz.enabled: false`); see Known limitations
- **`services/argocd-appset/values.yaml`** — `pgMain` entry (wave 5, `destNamespace: data`,
  `dopplerConfig: svc_pg`, ignoreDifferences for operator-mutated SGCluster/SGPostgresConfig fields)

### User-side prereqs (block sync until done)
1. **Doppler config `svc_pg`** (devops project) with:
   - `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` (R2 API token)
   - (later) `<SVC>_PG_PASSWORD` per consumer
   - machine token must be project-scoped for this config
2. **R2 bucket** `stackgres-pg-main` created
3. **values.yaml**: set real R2 endpoint (`https://<CF_ACCOUNT_ID>.r2.cloudflarestorage.com`)
   — currently a placeholder

### Verified during research
- StackGres operator healthy (`postgres-operator` ns, 2 pods Running); `openagent-pg` live on PG 18.3
  with NO backups configured (this adds them)
- `SGBackupConfig` CRD does NOT exist in this operator → schedules are inline in `SGCluster.spec.backups`
- `SGObjectStorage` is `stackgres.io/v1beta1` with `s3Compatible.awsCredentials.secretKeySelectors`
- Chart renders clean: `helm template` validated (6 resources, correct waves)

### Known limitations / watch items
- **Authz policy ships disabled**: operator ns is NOT ambient; a principal-based ALLOW would block
  non-mesh operator management traffic to the cluster. Enable (`authz.enabled: true` + principals)
  only after testing operator↔cluster connectivity under the policy; also label `data` ns ambient.
- `SGObjectStorage.spec.s3Compatible.path` — verify CRD keeps it (if pruned, backups land at bucket
  root; add ignoreDifferences if a diff loop appears during test-sync)
- Plane boots on PG 18 = gate at Plane deployment (fallback: second SGCluster at 16, documented)
