### PR TITLE
feat(openagent): drawio MCP for architecture diagrams

### DIFF
--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -337,6 +337,16 @@ hermes-agent:
           resources: false
           prompts: false
 
+      drawio:
+        command: "sh"
+        args:
+          - "-c"
+          - "exec $HOME/.deno/bin/deno run --allow-net --allow-read --allow-env https://raw.githubusercontent.com/simonkurtz-MSFT/drawio-mcp-server/main/src/index.ts"
+        timeout: 120
+        tools:
+          resources: false
+          prompts: false
+
       google-workspace:
         command: "uvx"
         args: ["workspace-mcp", "--tool-tier", "complete"]
@@ -465,6 +475,7 @@ hermes-agent:
       if [ ! -f /usr/local/bin/obscura ]; then
         curl -sL https://github.com/h4ckf0r0day/obscura/releases/download/v0.2.0/obscura-aarch64-linux-stealth.tar.gz | tar -xz -C /usr/local/bin
       fi
+<<<<<<< Updated upstream
       export PATH=$HOME/.local/bin:$PATH
       # Agent Reach deps
       command -v agent-reach >/dev/null 2>&1 || uv tool install https://github.com/Panniantong/agent-reach/archive/main.zip 2>&1
@@ -472,6 +483,16 @@ hermes-agent:
       command -v gallery-dl >/dev/null 2>&1 || uv tool install gallery-dl 2>&1
       mkdir -p $HOME/.config/yt-dlp && { grep -qxF -- '--js-runtimes node' $HOME/.config/yt-dlp/config 2>/dev/null || printf '%s\n' '--js-runtimes node' >> $HOME/.config/yt-dlp/config; }
       # Doppler CLI
+=======
+      # deno (drawio MCP — headless draw.io XML generation)
+      if [ ! -f $HOME/.deno/bin/deno ]; then
+        curl -fsSL https://deno.land/install.sh | sh -s -- -y
+      fi
+      export PATH=$HOME/.local/bin:$HOME/.deno/bin:$PATH
+      # (cli.doppler.com/download). gpgv signature verify skipped: container
+      # runs uid 10000 w/o sudo, so gnupg can't be installed here. Installs to
+      # the PVC /opt/data/bin (user-writable, survives restarts).
+>>>>>>> Stashed changes
       if [ ! -x /opt/data/bin/doppler ]; then
         mkdir -p /opt/data/bin
         DOP_ARCH=$(uname -m | sed 's/aarch64/arm64/; s/x86_64/amd64/')

--- a/services/helm/openagent/values.yaml
+++ b/services/helm/openagent/values.yaml
@@ -475,24 +475,20 @@ hermes-agent:
       if [ ! -f /usr/local/bin/obscura ]; then
         curl -sL https://github.com/h4ckf0r0day/obscura/releases/download/v0.2.0/obscura-aarch64-linux-stealth.tar.gz | tar -xz -C /usr/local/bin
       fi
-<<<<<<< Updated upstream
-      export PATH=$HOME/.local/bin:$PATH
+      export PATH=$HOME/.local/bin:$HOME/.deno/bin:$PATH
       # Agent Reach deps
       command -v agent-reach >/dev/null 2>&1 || uv tool install https://github.com/Panniantong/agent-reach/archive/main.zip 2>&1
       command -v yt-dlp >/dev/null 2>&1 || uv tool install yt-dlp 2>&1
       command -v gallery-dl >/dev/null 2>&1 || uv tool install gallery-dl 2>&1
       mkdir -p $HOME/.config/yt-dlp && { grep -qxF -- '--js-runtimes node' $HOME/.config/yt-dlp/config 2>/dev/null || printf '%s\n' '--js-runtimes node' >> $HOME/.config/yt-dlp/config; }
-      # Doppler CLI
-=======
       # deno (drawio MCP — headless draw.io XML generation)
       if [ ! -f $HOME/.deno/bin/deno ]; then
         curl -fsSL https://deno.land/install.sh | sh -s -- -y
       fi
-      export PATH=$HOME/.local/bin:$HOME/.deno/bin:$PATH
+      # Doppler CLI — same binary endpoint the official install script uses
       # (cli.doppler.com/download). gpgv signature verify skipped: container
       # runs uid 10000 w/o sudo, so gnupg can't be installed here. Installs to
       # the PVC /opt/data/bin (user-writable, survives restarts).
->>>>>>> Stashed changes
       if [ ! -x /opt/data/bin/doppler ]; then
         mkdir -p /opt/data/bin
         DOP_ARCH=$(uname -m | sed 's/aarch64/arm64/; s/x86_64/amd64/')


### PR DESCRIPTION
## draw.io MCP for Hermes (headless diagram generation)

Wire the **simonkurtz-MSFT/drawio-mcp-server** into Hermes so I can produce/edit
draw.io architecture diagrams on demand (deliverable: `.drawio` XML — opens natively
at draw.maklab.net for interactive editing).

### Changes (`services/helm/openagent/values.yaml`)
- `hermes-agent.command` block: idempotent **Deno install** to `$HOME/.deno/bin` (user-writable,
  same pattern as obscura/go) + PATH export
- `hermes-agent.config.mcp_servers.drawio`: stdio MCP running
  `deno run --allow-net --allow-read --allow-env <repo>/src/index.ts` (stateless XML generator —
  no browser/extension needed in the pod)

### Why this server (vs lgazo/drawio-mcp-server)
- lgazo = bridge to a LIVE draw.io instance via browser extension + WebSocket back to the MCP server
  → requires exposing the pod's WS endpoint + a browser extension; not viable headless
- simonkurtz fork = headless XML generation (Deno, stateless, fully offline) — output is standard
  `.drawio` files, open/edit at draw.maklab.net

### Verify after deploy
- Pod restart → `deno` present in `/opt/data/.deno/bin`
- Hermes MCP list shows `drawio` tools (`add-cells`, `export-diagram`, `search-shapes`, …)
- Generate a diagram → XML opens in draw.maklab.net
